### PR TITLE
instructions to run 'git apply' contain non-existing flag

### DIFF
--- a/src/main/java/org/openrewrite/maven/RewriteDiffMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDiffMojo.java
@@ -85,7 +85,7 @@ public class RewriteDiffMojo extends AbstractRewriteMojo {
                 throw new MojoExecutionException("Unable to generate rewrite diff file.", e);
             }
 
-            getLog().warn("A patch file has been generated. Run 'git apply -f " +
+            getLog().warn("A patch file has been generated. Run 'git apply " +
                     Paths.get(mavenSession.getExecutionRootDirectory()).relativize(patchFile).toString() + "' to apply.");
         }
     }


### PR DESCRIPTION
There does not appear to be a `-f` flag for `git apply`:

https://git-scm.com/docs/git-apply
