### PR TITLE
publish: add 'skipCycloneDxBom' parameter

### DIFF
--- a/src/it/publish-skip-cyclone-dx-bom/invoker.properties
+++ b/src/it/publish-skip-cyclone-dx-bom/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = org.openrewrite.maven:rewrite-maven-plugin:publish
+invoker.name = Test that generating the CycloneDX BOM can be skipped

--- a/src/it/publish-skip-cyclone-dx-bom/pom.xml
+++ b/src/it/publish-skip-cyclone-dx-bom/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>publish-skip-cyclone-dx-bom</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>29.0-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite.plan</groupId>
+            <artifactId>rewrite-checkstyle</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <skipCycloneDxBom>true</skipCycloneDxBom>
+                    <configLocation>${maven.multiModuleProjectDirectory}/src/it/rewrite.yml</configLocation>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/publish-skip-cyclone-dx-bom/src/main/java/sample/HelloWorld.java
+++ b/src/it/publish-skip-cyclone-dx-bom/src/main/java/sample/HelloWorld.java
@@ -1,0 +1,7 @@
+package sample;
+
+public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello, world!");
+    }
+}

--- a/src/it/publish-skip-cyclone-dx-bom/verify.groovy
+++ b/src/it/publish-skip-cyclone-dx-bom/verify.groovy
@@ -1,0 +1,6 @@
+File astJar = new File(basedir, "target/publish-skip-cyclone-dx-bom-0.1.0-SNAPSHOT-ast.jar")
+assert astJar.isFile()
+
+File cycloneDxBom = new File(basedir, "target/publish-skip-cyclone-dx-bom-0.1.0-SNAPSHOT-cyclonedx.xml")
+assert !cycloneDxBom.isFile() && !cycloneDxBom.exists()
+


### PR DESCRIPTION
This change allows the publish mojo to skip the building and attaching
of a CycloneDX BOM artifact to the project if the parameter
`skipCycloneDxBom` is set to true (default value is false).

Related to [#59][0], generating this artifact fails for projects where
the parent pom is not in Maven Central, so adding this property is
mostly a workaround to the failure but might have other uses as well.

[0]: https://github.com/openrewrite/rewrite-maven-plugin/issues/59
