### PR TITLE
github actions for automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
           git config user.name "github-actions[bot]"
 
       - name: release
-        timeout-minutes: 30
-        run: ./mvnw --settings=${{ github.workspace }}/settings.xml --file=pom.xml -Prelease --batch-mode release:prepare release:perform
+        timeout-minutes: 45
+        run: ./mvnw --settings=${{ github.workspace }}/settings.xml --file=pom.xml --activate-profiles=release,release-automation --batch-mode help:active-profiles release:prepare release:perform
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -43,6 +43,6 @@ jobs:
 
       - name: rollback
         if: ${{ failure() }}
-        run: ./mvnw --settings=${{github.workspace}}/settings.xml --file=pom.xml -Prelease --batch-mode release:rollback
+        run: ./mvnw --settings=${{github.workspace}}/settings.xml --file=pom.xml --activate-profiles=release,release-automation --batch-mode help:active-profiles release:rollback
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+---
+name: release
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: set-up-jdk
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11"
+          server-id: ossrh
+          settings-path: ${{ github.workspace }}
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: configure-git-user
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+      - name: release
+        timeout-minutes: 30
+        run: ./mvnw --settings=${{ github.workspace }}/settings.xml --file=pom.xml -Prelease --batch-mode release:prepare release:perform
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: rollback
+        if: ${{ failure() }}
+        run: ./mvnw --settings=${{github.workspace}}/settings.xml --file=pom.xml -Prelease --batch-mode release:rollback
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <scm>
         <connection>scm:git:https://github.com/openrewrite/rewrite-maven-plugin.git</connection>
-		<developerConnection>${developerConnectionUrl}</developerConnection>
+        <developerConnection>${developerConnectionUrl}</developerConnection>
         <url>https://github.com/openrewrite/rewrite-maven-plugin/tree/master</url>
         <tag>v2.1.0</tag>
     </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <connection>scm:git:https://github.com/openrewrite/rewrite-maven-plugin.git</connection>
         <developerConnection>${developerConnectionUrl}</developerConnection>
         <url>https://github.com/openrewrite/rewrite-maven-plugin/tree/master</url>
-        <tag>v2.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>
@@ -207,6 +207,7 @@
                 <version>3.0.0-M1</version>
                 <configuration>
                     <releaseProfiles>release</releaseProfiles>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -255,10 +255,6 @@
     <profiles>
         <profile>
             <id>release</id>
-            <properties>
-                <!-- automation via the maven-release-plugin uses a GITHUB_TOKEN which requires 'https' urls for git pushing -->
-                <developerConnectionUrl>scm:git:https://github.com/openrewrite/rewrite-maven-plugin.git</developerConnectionUrl>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -323,6 +319,14 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <!-- generally should be stacked after the 'release' profile, but in some cases we may want to discern between a ci-cd system performing the release; and if the situation requires it, a human performing the release -->
+            <id>release-automation</id>
+            <properties>
+                <!-- automation via the maven-release-plugin uses a GITHUB_TOKEN which requires 'https' urls for git pushing -->
+                <developerConnectionUrl>scm:git:https://github.com/openrewrite/rewrite-maven-plugin.git</developerConnectionUrl>
+            </properties>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,14 @@
 
     <scm>
         <connection>scm:git:https://github.com/openrewrite/rewrite-maven-plugin.git</connection>
-        <developerConnection>scm:git:https://github.com/openrewrite/rewrite-maven-plugin.git</developerConnection>
+		<developerConnection>${developerConnectionUrl}</developerConnection>
         <url>https://github.com/openrewrite/rewrite-maven-plugin/tree/master</url>
         <tag>v2.1.0</tag>
     </scm>
 
     <properties>
+        <!-- using 'ssh' url scheme by default, which assumes a human is performing git operations leveraging an ssh key -->
+        <developerConnectionUrl>scm:git:ssh://git@github.com/openrewrite/rewrite-maven-plugin.git</developerConnectionUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <rewrite.version>6.1.14</rewrite.version>
@@ -253,6 +255,10 @@
     <profiles>
         <profile>
             <id>release</id>
+            <properties>
+                <!-- automation via the maven-release-plugin uses a GITHUB_TOKEN which requires 'https' urls for git pushing -->
+                <developerConnectionUrl>scm:git:https://github.com/openrewrite/rewrite-maven-plugin.git</developerConnectionUrl>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
 
     <scm>
         <connection>scm:git:https://github.com/openrewrite/rewrite-maven-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/openrewrite/rewrite-maven-plugin.git</developerConnection>
+        <developerConnection>scm:git:https://github.com/openrewrite/rewrite-maven-plugin.git</developerConnection>
         <url>https://github.com/openrewrite/rewrite-maven-plugin/tree/master</url>
-      <tag>v2.1.0</tag>
+        <tag>v2.1.0</tag>
     </scm>
 
     <properties>
@@ -294,6 +294,13 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <!-- Prevent gpg from using pinentry programs. Fixes: gpg: signing failed: Inappropriate ioctl for device -->
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
part of https://github.com/openrewrite/rewrite-maven-plugin/issues/79

This demonstrates how the current workflow of releasing could be uplifted to github actions; the biggest benefit being not requiring a shared set of credentials directly on the releaser's computers -- instead, stored as repository secrets.

Currently can be ran manually ran from the `actions` UI (though would be beneficial to one day have this trigger automatically on a `git tag` and push rather than the other way around).

An example of this in action can be seen here: https://github.com/slugstack/rewrite-definitions/runs/1751552089?check_suite_focus=true

Requires the following github secrets defined on the repository:

MAVEN_GPG_PASSPHRASE
MAVEN_GPG_PRIVATE_KEY
OSSRH_TOKEN
OSSRH_USERNAME