### PR TITLE
Adding pom caching to maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.openrewrite.maven</groupId>
     <artifactId>rewrite-maven-plugin</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <name>rewrite-maven-plugin</name>
 
     <packaging>maven-plugin</packaging>
@@ -44,7 +44,8 @@
         <developerConnectionUrl>scm:git:ssh://git@github.com/openrewrite/rewrite-maven-plugin.git</developerConnectionUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <rewrite.version>7.0.1</rewrite.version>
+        <rewrite.version>7.1.0-SNAPSHOT</rewrite.version>
+        <rocksdbjni.version>6.15.5</rocksdbjni.version>
 
         <!-- Plugins -->
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
@@ -119,6 +120,11 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>3.6.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.rocksdb</groupId>
+            <artifactId>rocksdbjni</artifactId>
+            <version>${rocksdbjni.version}</version>
         </dependency>
         <dependency>
             <!-- needed when injecting the Maven Project into a plugin  -->

--- a/src/it/multi-module-project/pom.xml
+++ b/src/it/multi-module-project/pom.xml
@@ -26,6 +26,7 @@
                             <recipe>com.yourorg.CodeCleanup</recipe>
                         </activeRecipes>
                         <configLocation>${maven.multiModuleProjectDirectory}/src/it/rewrite.yml</configLocation>
+                        <pomCacheDirectory>${project.build.directory}/pomCache</pomCacheDirectory>
                     </configuration>
                 </plugin>
             </plugins>

--- a/src/it/single-project/pom.xml
+++ b/src/it/single-project/pom.xml
@@ -43,6 +43,7 @@
                     <activeRecipes>
                         <recipe>com.yourorg.CodeCleanup</recipe>
                     </activeRecipes>
+                    <pomCacheDirectory>${project.build.directory}/pomCache</pomCacheDirectory>
                     <configLocation>${maven.multiModuleProjectDirectory}/src/it/rewrite.yml</configLocation>
                 </configuration>
             </plugin>

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -61,6 +61,10 @@ public abstract class AbstractRewriteMojo extends AbstractMojo {
     @Parameter(property = "pomCacheEnabled", defaultValue = "true")
     private boolean pomCacheEnabled;
 
+    @Nullable
+    @Parameter(property = "pomCacheDirectory")
+    private String pomCacheDirectory;
+
     protected Environment environment() throws MojoExecutionException {
         Environment.Builder env = Environment
                 .builder(project.getProperties())
@@ -123,7 +127,12 @@ public abstract class AbstractRewriteMojo extends AbstractMojo {
                 .mavenConfig(baseDir.resolve(".mvn/maven.config"));
 
         if (pomCacheEnabled) {
-            mavenParserBuilder.cache(new RocksdbMavenPomCache(Paths.get(System.getProperty("user.home"), ".rewrite-cache", "pom").toFile()));
+            if (pomCacheDirectory != null) {
+                mavenParserBuilder.cache(new RocksdbMavenPomCache(Paths.get(pomCacheDirectory).toFile()));
+            } else {
+                //Default directory is "~/.rewrite/cache/pom"
+                mavenParserBuilder.cache(new RocksdbMavenPomCache(Paths.get(System.getProperty("user.home"), ".rewrite", "cache", "pom").toFile()));
+            }
         }
 
         Path mavenSettings = Paths.get(System.getProperty("user.home")).resolve(".m2/settings.xml");

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -123,7 +123,7 @@ public abstract class AbstractRewriteMojo extends AbstractMojo {
                 .mavenConfig(baseDir.resolve(".mvn/maven.config"));
 
         if (pomCacheEnabled) {
-            mavenParserBuilder.cache(new RocksdbMavenPomCache(Paths.get(System.getProperty("user.home"), ".rewrite-cache", "rockdb").toFile()));
+            mavenParserBuilder.cache(new RocksdbMavenPomCache(Paths.get(System.getProperty("user.home"), ".rewrite-cache", "pom").toFile()));
         }
 
         Path mavenSettings = Paths.get(System.getProperty("user.home")).resolve(".m2/settings.xml");


### PR DESCRIPTION
This enhancement enables rewrite's pom caching mechanism. The use of caching improves the execution time substantially after the cache has been primed. The poms are stored in a directory on the file system (the default is `~/.rewrite-cache/poms`). The cache is "on" by default and can be toggled via the 'pomCacheEnabled' configuration property.

