### PR TITLE
remove build plugin from submodule pom xmls in tests

### DIFF
--- a/src/test/resources-its/org/openrewrite/maven/PomCacheIT/multi_module_project/a/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/PomCacheIT/multi_module_project/a/pom.xml
@@ -15,13 +15,5 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>@project.groupId@</groupId>
-                <artifactId>@project.artifactId@</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+    
 </project>

--- a/src/test/resources-its/org/openrewrite/maven/PomCacheIT/multi_module_project/b/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/PomCacheIT/multi_module_project/b/pom.xml
@@ -24,12 +24,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>@project.groupId@</groupId>
-                <artifactId>@project.artifactId@</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/test/resources-its/org/openrewrite/maven/PomCacheIT/multi_module_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/PomCacheIT/multi_module_project/pom.xml
@@ -15,20 +15,18 @@
     </modules>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>@project.groupId@</groupId>
-                    <artifactId>@project.artifactId@</artifactId>
-                    <version>@project.version@</version>
-                    <configuration>
-                        <activeRecipes>
-                            <recipe>org.openrewrite.java.format.AutoFormat</recipe>
-                        </activeRecipes>
-                        <pomCacheDirectory>${project.build.directory}/pomCache</pomCacheDirectory>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>org.openrewrite.java.format.AutoFormat</recipe>
+                    </activeRecipes>
+                    <pomCacheDirectory>${project.build.directory}/pomCache</pomCacheDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteCycloneDxIT/multi_module_project/a/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteCycloneDxIT/multi_module_project/a/pom.xml
@@ -16,12 +16,4 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>@project.groupId@</groupId>
-                <artifactId>@project.artifactId@</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteCycloneDxIT/multi_module_project/b/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteCycloneDxIT/multi_module_project/b/pom.xml
@@ -24,12 +24,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>@project.groupId@</groupId>
-                <artifactId>@project.artifactId@</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteCycloneDxIT/multi_module_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteCycloneDxIT/multi_module_project/pom.xml
@@ -15,14 +15,12 @@
     </modules>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>@project.groupId@</groupId>
-                    <artifactId>@project.artifactId@</artifactId>
-                    <version>@project.version@</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/a/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/a/pom.xml
@@ -16,12 +16,4 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>@project.groupId@</groupId>
-                <artifactId>@project.artifactId@</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/b/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/b/pom.xml
@@ -24,12 +24,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>@project.groupId@</groupId>
-                <artifactId>@project.artifactId@</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/pom.xml
@@ -14,22 +14,20 @@
     </modules>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>@project.groupId@</groupId>
-                    <artifactId>@project.artifactId@</artifactId>
-                    <version>@project.version@</version>
-                    <configuration>
-                        <activeRecipes>
-                            <recipe>com.example.RewriteDryRunIT.CodeCleanup</recipe>
-                        </activeRecipes>
-                        <configLocation>
-                            ${maven.multiModuleProjectDirectory}/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/rewrite.yml
-                        </configLocation>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>com.example.RewriteDryRunIT.CodeCleanup</recipe>
+                    </activeRecipes>
+                    <configLocation>
+                        ${maven.multiModuleProjectDirectory}/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/rewrite.yml
+                    </configLocation>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/a/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/a/pom.xml
@@ -16,12 +16,4 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>@project.groupId@</groupId>
-                <artifactId>@project.artifactId@</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/b/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/b/pom.xml
@@ -23,13 +23,5 @@
             <version>1.0</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>@project.groupId@</groupId>
-                <artifactId>@project.artifactId@</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+    
 </project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/pom.xml
@@ -14,22 +14,20 @@
     </modules>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>@project.groupId@</groupId>
-                    <artifactId>@project.artifactId@</artifactId>
-                    <version>@project.version@</version>
-                    <configuration>
-                        <activeRecipes>
-                            <recipe>com.example.RewriteRunIT.CodeCleanup</recipe>
-                        </activeRecipes>
-                        <configLocation>
-                            ${maven.multiModuleProjectDirectory}/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/rewrite.yml
-                        </configLocation>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>com.example.RewriteRunIT.CodeCleanup</recipe>
+                    </activeRecipes>
+                    <configLocation>
+                        ${maven.multiModuleProjectDirectory}/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/rewrite.yml
+                    </configLocation>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>


### PR DESCRIPTION
Remove the build plugin declaration from submodules, only have the plugin applied to the root pom.xml.