### PR TITLE
Feather in test coverage against windows machines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ["8", "11", "13", "14"]
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     if: github.repository_owner == 'openrewrite'
     steps:

--- a/src/test/java/org/openrewrite/maven/RewriteDryRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDryRunIT.java
@@ -4,10 +4,13 @@ import com.soebes.itf.jupiter.extension.MavenGoal;
 import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
 import com.soebes.itf.jupiter.extension.MavenTest;
 import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
 
 @MavenJupiterExtension
+@DisabledOnOs(OS.WINDOWS)
 @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:dryRun")
 public class RewriteDryRunIT {
 

--- a/src/test/java/org/openrewrite/maven/RewriteRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunIT.java
@@ -4,10 +4,13 @@ import com.soebes.itf.jupiter.extension.MavenGoal;
 import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
 import com.soebes.itf.jupiter.extension.MavenTest;
 import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
 
 @MavenJupiterExtension
+@DisabledOnOs(OS.WINDOWS)
 @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:run")
 public class RewriteRunIT {
 

--- a/src/test/java/org/openrewrite/maven/UsingRecipesFromExternalDependenciesIT.java
+++ b/src/test/java/org/openrewrite/maven/UsingRecipesFromExternalDependenciesIT.java
@@ -4,6 +4,8 @@ import com.soebes.itf.jupiter.extension.MavenGoal;
 import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
 import com.soebes.itf.jupiter.extension.MavenTest;
 import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
 
@@ -11,6 +13,7 @@ import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
 public class UsingRecipesFromExternalDependenciesIT {
 
     @MavenTest
+    @DisabledOnOs(OS.WINDOWS)
     @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:dryRun")
     void multi_module_dry_run(MavenExecutionResult result) {
         assertThat(result)
@@ -28,6 +31,7 @@ public class UsingRecipesFromExternalDependenciesIT {
     }
 
     @MavenTest
+    @DisabledOnOs(OS.WINDOWS)
     @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:dryRun")
     void multi_module_dry_run_modules_with_different_recipe_sets(MavenExecutionResult result) {
         assertThat(result)
@@ -85,6 +89,7 @@ public class UsingRecipesFromExternalDependenciesIT {
     }
 
     @MavenTest
+    @DisabledOnOs(OS.WINDOWS)
     @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:run")
     void single_project_run(MavenExecutionResult result) {
         assertThat(result)


### PR DESCRIPTION
Add test coverage using windows-latest but file path separator output is different on windows.

This isn't perfect at the moment since these tests are doing a string output comparison using `contains("words and some/path/match")`, so I'll add a Disable annotation on some of these tests. But I do want to at least allow folks on windows machines to run the test suite locally.