### PR TITLE
rewrite:discover default should only show top-level discovered recipes

### DIFF
--- a/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
@@ -4,7 +4,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.openrewrite.Recipe;
-import org.openrewrite.config.*;
+import org.openrewrite.config.Environment;
+import org.openrewrite.config.OptionDescriptor;
+import org.openrewrite.config.RecipeDescriptor;
 
 import java.util.Collection;
 
@@ -45,9 +47,11 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
             log.info("    " + recipe.getName());
         }
         log.info("");
-        log.info("Descriptors:");
-        for (RecipeDescriptor recipeDescriptor : env.listRecipeDescriptors()) {
-            logRecipeDescriptor(recipeDescriptor, verbose, recursive);
+        if (verbose) {
+            log.info("Descriptors:");
+            for (RecipeDescriptor recipeDescriptor : env.listRecipeDescriptors()) {
+                logRecipeDescriptor(recipeDescriptor, verbose, recursive);
+            }
         }
     }
 
@@ -72,7 +76,7 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
                 if (optionDescriptor.isRequired()) {
                     optionBuilder.append("!");
                 }
-                log.info("        " + optionBuilder.toString());
+                log.info("        " + optionBuilder);
                 if (verbose) {
                     log.info("        Display name: " + optionDescriptor.getDisplayName());
                     log.info("        Description: " + optionDescriptor.getDescription());

--- a/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
@@ -3,6 +3,7 @@ package org.openrewrite.maven;
 import com.soebes.itf.jupiter.extension.MavenGoal;
 import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
 import com.soebes.itf.jupiter.extension.MavenTest;
+import com.soebes.itf.jupiter.extension.SystemProperty;
 import com.soebes.itf.jupiter.maven.MavenExecutionResult;
 
 import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
@@ -12,13 +13,31 @@ import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
 public class RewriteDiscoverIT {
 
     @MavenTest
-    void rewrite_discover_has_output(MavenExecutionResult result) {
+    void rewrite_discover_default_output(MavenExecutionResult result) {
         assertThat(result)
                 .isSuccessful()
                 .out()
                 .plain()
                 .matches(logLines ->
                         logLines.stream().anyMatch(logLine -> logLine.contains("org.openrewrite.java.format.AutoFormat"))
+                )
+                .matches(logLines ->
+                        logLines.stream().noneMatch(logLine -> logLine.contains("Descriptors"))
+                )
+        ;
+
+        assertThat(result).out().warn().isEmpty();
+    }
+
+    @MavenTest
+    @SystemProperty(value = "rewrite.discover.verbose", content = "true")
+    void rewrite_discover_verbose_output(MavenExecutionResult result) {
+        assertThat(result)
+                .isSuccessful()
+                .out()
+                .plain()
+                .matches(logLines ->
+                        logLines.stream().anyMatch(logLine -> logLine.contains("Descriptors"))
                 );
 
         assertThat(result).out().warn().isEmpty();

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_default_output/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_default_output/pom.xml
@@ -4,10 +4,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.openrewrite.maven</groupId>
-    <artifactId>rewrite_discover_has_output</artifactId>
+    <artifactId>rewrite_discover_default_output</artifactId>
     <version>1.0</version>
     <packaging>jar</packaging>
-    <name>RewriteDiscoverIT#rewrite_discover_has_output</name>
+    <name>RewriteDiscoverIT#rewrite_discover_default_output</name>
 
     <build>
         <plugins>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_verbose_output/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_verbose_output/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>rewrite_discover_verbose_output</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>RewriteDiscoverIT#rewrite_discover_verbose_output</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
closes https://github.com/openrewrite/rewrite-maven-plugin/issues/134

Now by default, `rewrite:discover` will only show top-level discoverable recipes rather than fully displaying `Descriptors:` underneath.

This output will receive more love in later PRs, but for this exact moment let's at least set the default to prevent this from blowing out the console log.