### PR TITLE
Maven-plugin-plugin to generate rewrite:help

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ If you're looking for more information on the output from a test, try checking t
 ### Using this plugin against itself
 
 The `pom.xml` has the most recent officially-released version of the `rewrite-maven-plugin` applied to itself (it's a helpful plugin, why not use it to help develop itself?) Try `./mvnw rewrite:dryRun`.
+
+### Resource guides
+
+- https://carlosvin.github.io/posts/creating-custom-maven-plugin/en/#_dependency_injection
+- https://developer.okta.com/blog/2019/09/23/tutorial-build-a-maven-plugin
+- https://medium.com/swlh/step-by-step-guide-to-developing-a-custom-maven-plugin-b6e3a0e09966

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>${maven-plugin-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-descriptor</id>
+                        <phase>process-classes</phase>
+                    </execution>
+                    <execution>
+                        <id>generated-helpmojo</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/openrewrite/maven/CycloneDxBomMojo.java
+++ b/src/main/java/org/openrewrite/maven/CycloneDxBomMojo.java
@@ -14,7 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
- * Produce a Cyclone DX BOM for publication to Maven repositories
+ * Generates a CycloneDx bill of materials outlining all of the project's dependencies, including transitive dependencies.
  */
 @Mojo(name = "cyclonedx", requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true,
         defaultPhase = LifecyclePhase.PACKAGE)

--- a/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
@@ -10,6 +10,9 @@ import org.openrewrite.config.RecipeDescriptor;
 
 import java.util.Collection;
 
+/**
+ * Generate a list showing the available and applied recipes based on what Rewrite finds on your classpath.
+ */
 @Mojo(name = "discover", threadSafe = true)
 public class RewriteDiscoverMojo extends AbstractRewriteMojo {
     private final Log log = getLog();

--- a/src/main/java/org/openrewrite/maven/RewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDryRunMojo.java
@@ -22,6 +22,9 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.openrewrite.Result;
 
+/**
+ * Generates warnings in the console for any recipes that would suggest changes, but does not make any changes.
+ */
 @Mojo(name = "dryRun", requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true,
         defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES)
 @Execute(phase = LifecyclePhase.PROCESS_TEST_CLASSES)

--- a/src/main/java/org/openrewrite/maven/RewriteRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteRunMojo.java
@@ -28,9 +28,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-// https://medium.com/swlh/step-by-step-guide-to-developing-a-custom-maven-plugin-b6e3a0e09966
-// https://carlosvin.github.io/posts/creating-custom-maven-plugin/en/#_dependency_injection
-// https://developer.okta.com/blog/2019/09/23/tutorial-build-a-maven-plugin
+/**
+ * Runs the configured recipes and applies the changes locally.
+ */
 @Mojo(name = "run", requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 @Execute(phase = LifecyclePhase.PROCESS_TEST_CLASSES)
 public class RewriteRunMojo extends AbstractRewriteMojo {


### PR DESCRIPTION
closes https://github.com/openrewrite/rewrite-maven-plugin/issues/141

Updated the javadoc on these classes to use the goals descriptions referenced from https://docs.openrewrite.org/reference/rewrite-maven-plugin

Result as it stands, could be quickly tidied up and possibly whether reference URL could be included:

```txt
  Eliminate technical debt. At build time.

This plugin has 5 goals:

rewrite:cyclonedx
  Produce a Cyclone DX BOM for publication to Maven repositories

rewrite:discover

rewrite:dryRun

rewrite:help
  Display help information on rewrite-maven-plugin.
  Call mvn rewrite:help -Ddetail=true -Dgoal=<goal-name> to display parameter
  details.

rewrite:run
```

after

```
[INFO] rewrite-maven-plugin 4.1.1-SNAPSHOT
  Eliminate technical debt. At build time.

This plugin has 5 goals:

rewrite:cyclonedx
  Generates a CycloneDx bill of materials outlining all of the project's
  dependencies, including transitive dependencies.

rewrite:discover
  Generate a list showing the available and applied recipes based on what
  Rewrite finds on your classpath.

rewrite:dryRun
  Generates warnings in the console for any recipes that would suggest changes,
  but does not make any changes.

rewrite:help
  Display help information on rewrite-maven-plugin.
  Call mvn rewrite:help -Ddetail=true -Dgoal=<goal-name> to display parameter
  details.

rewrite:run
  Runs the configured recipes and applies the changes locally.
```

Can be improved in the future.