### PR TITLE
fix rewrite.discover parameter discovery and polish help docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -453,12 +453,20 @@
                     <plugin>
                         <groupId>org.openrewrite.maven</groupId>
                         <artifactId>rewrite-maven-plugin</artifactId>
-                        <version>4.1.1</version>
+                        <version>4.1.2</version>
                         <configuration>
                             <activeRecipes>
                                 <recipe>org.openrewrite.java.format.AutoFormat</recipe>
+                                <recipe>org.openrewrite.java.testing.junit5.JUnit5BestPractices</recipe>
                             </activeRecipes>
                         </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.openrewrite.recipe</groupId>
+                                <artifactId>rewrite-testing-frameworks</artifactId>
+                                <version>1.2.1</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/src/main/java/org/openrewrite/maven/CycloneDxBomMojo.java
+++ b/src/main/java/org/openrewrite/maven/CycloneDxBomMojo.java
@@ -17,7 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
- * Generates a CycloneDx bill of materials outlining all of the project's dependencies, including transitive dependencies.
+ * Generate a CycloneDx bill of materials outlining the project's dependencies, including transitive dependencies.
  */
 @Mojo(name = "cyclonedx", requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true,
         defaultPhase = LifecyclePhase.PACKAGE)

--- a/src/main/java/org/openrewrite/maven/RewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDryRunMojo.java
@@ -23,7 +23,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.openrewrite.Result;
 
 /**
- * Generates warnings in the console for any recipes that would suggest changes, but does not make any changes.
+ * Display warnings for any recipes that would suggest changes, but does not make any changes.
  */
 @Mojo(name = "dryRun", requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true,
         defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES)

--- a/src/main/java/org/openrewrite/maven/RewriteRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteRunMojo.java
@@ -29,7 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
- * Runs the configured recipes and applies the changes locally.
+ * Run the configured recipes and applies the changes locally.
  */
 @Mojo(name = "run", requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 @Execute(phase = LifecyclePhase.PROCESS_TEST_CLASSES)

--- a/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
@@ -23,24 +23,21 @@ public class RewriteDiscoverIT {
                 )
                 .matches(logLines ->
                         logLines.stream().noneMatch(logLine -> logLine.contains("Descriptors"))
-                )
-        ;
+                );
 
         assertThat(result).out().warn().isEmpty();
     }
 
     @MavenTest
-    @SystemProperty(value = "rewrite.discover.verbose", content = "true")
-    void rewrite_discover_verbose_output(MavenExecutionResult result) {
+    @SystemProperty(value = "recipe", content = "org.openrewrite.JAVA.format.AutoFormAT")
+    void rewrite_discover_recipe_lookup_case_insensitive(MavenExecutionResult result) {
         assertThat(result)
                 .isSuccessful()
                 .out()
                 .info()
                 .matches(logLines ->
-                        logLines.stream().anyMatch(logLine -> logLine.contains("Descriptors"))
+                        logLines.stream().anyMatch(logLine -> logLine.contains("org.openrewrite.java.format.AutoFormat"))
                 );
-
-        assertThat(result).out().warn().isEmpty();
     }
 
     @MavenTest
@@ -51,6 +48,19 @@ public class RewriteDiscoverIT {
                 .info()
                 .matches(logLines ->
                         logLines.stream().anyMatch(logLine -> logLine.contains("com.example.RewriteDiscoverIT.CodeCleanup"))
+                );
+
+        assertThat(result).out().warn().isEmpty();
+    }
+
+    @MavenTest
+    void rewrite_discover_verbose_output(MavenExecutionResult result) {
+        assertThat(result)
+                .isSuccessful()
+                .out()
+                .info()
+                .matches(logLines ->
+                        logLines.stream().anyMatch(logLine -> logLine.contains("Descriptors"))
                 );
 
         assertThat(result).out().warn().isEmpty();

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_reads_rewrite_yml/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_reads_rewrite_yml/pom.xml
@@ -16,9 +16,9 @@
                 <artifactId>@project.artifactId@</artifactId>
                 <version>@project.version@</version>
                 <configuration>
-                    <activeRecipe>
+                    <activeRecipes>
                         <recipe>com.example.RewriteDiscoverIT.CodeCleanup</recipe>
-                    </activeRecipe>
+                    </activeRecipes>
                     <configLocation>
                         ${maven.multiModuleProjectDirectory}/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_reads_rewrite_yml/rewrite.yml
                     </configLocation>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_recipe_lookup_case_insensitive/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_recipe_lookup_case_insensitive/pom.xml
@@ -4,14 +4,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.openrewrite.maven</groupId>
-    <artifactId>rewrite_discover_verbose_output</artifactId>
+    <artifactId>rewrite_discover_recipe_lookup_case_insensitive</artifactId>
     <version>1.0</version>
     <packaging>jar</packaging>
-    <name>RewriteDiscoverIT#rewrite_discover_verbose_output</name>
-
-    <properties>
-        <rewrite.discover.verbose>true</rewrite.discover.verbose>
-    </properties>
+    <name>RewriteDiscoverIT#rewrite_discover_recipe_lookup_case_insensitive</name>
 
     <build>
         <plugins>


### PR DESCRIPTION
cherry-picking polish from https://github.com/openrewrite/rewrite-maven-plugin/pull/150 to merge it in faster and it not be contingent on features

- Move `discovery` features to parameters to make them discoverable through `./mvnw rewrite:help` (closes #137)
- Make `rewrite.discover.filter` just `recipe` so it's easier to use (it's unlikely this was being aggressively used so we'll consider it not a big deal to have changed the parameter); make this case-insensitive, too.
- fix test which had `activeRecipe` instead of `activeRecipes`
- cleanup javadoc headers to be more succicint and use more present-tense verbage inkeeping with `help`
- rewrite-plugin bootstrap with activeRecipe from testing-frameworks
