### PR TITLE
simple indent method for formatting log messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.openrewrite.maven</groupId>
@@ -43,7 +44,8 @@
         <rewrite.version>7.2.2</rewrite.version>
 
         <!-- using 'ssh' url scheme by default, which assumes a human is performing git operations leveraging an ssh key -->
-        <developerConnectionUrl>scm:git:ssh://git@github.com/openrewrite/rewrite-maven-plugin.git</developerConnectionUrl>
+        <developerConnectionUrl>scm:git:ssh://git@github.com/openrewrite/rewrite-maven-plugin.git
+        </developerConnectionUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <rocksdbjni.version>6.19.3</rocksdbjni.version>

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -66,6 +66,11 @@ public abstract class AbstractRewriteMojo extends AbstractMojo {
     @Parameter(property = "pomCacheDirectory")
     private String pomCacheDirectory;
 
+    /**
+     * The prefix used to left-pad log messages, multiplied per "level" of log message.
+     */
+    private static final String LOG_INDENT_INCREMENT = "    ";
+
     protected Environment environment() throws MojoExecutionException {
         Environment.Builder env = Environment
                 .builder(project.getProperties())
@@ -339,7 +344,20 @@ public abstract class AbstractRewriteMojo extends AbstractMojo {
 
     protected void logRecipesThatMadeChanges(Result result) {
         for (Recipe recipe : result.getRecipesThatMadeChanges()) {
-            getLog().warn("  " + recipe.getName());
+            getLog().warn(indent(1, recipe.getName()));
         }
+    }
+
+    protected static StringBuilder indent(int indent, CharSequence content) {
+        StringBuilder prefix = repeat(indent, LOG_INDENT_INCREMENT);
+        return prefix.append(content);
+    }
+
+    private static StringBuilder repeat(int repeat, String str) {
+        StringBuilder buffer = new StringBuilder(repeat * str.length());
+        for (int i = 0; i < repeat; i++) {
+            buffer.append(str);
+        }
+        return buffer;
     }
 }

--- a/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
@@ -58,12 +58,12 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
 
         getLog().info("Active Recipes:");
         for (String activeRecipe : activeRecipes) {
-            getLog().info("    " + activeRecipe);
+            getLog().info(indent(1, activeRecipe));
         }
         getLog().info("");
         getLog().info("Activatable Recipes:");
         for (Recipe recipe : recipesByName) {
-            getLog().info("    " + recipe.getName());
+            getLog().info(indent(1, recipe.getName()));
         }
         getLog().info("");
         if (verbose) {
@@ -76,18 +76,18 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
 
     private void logRecipeDescriptor(RecipeDescriptor recipeDescriptor, boolean verbose, boolean recursive) {
         if (verbose) {
-            getLog().info("    Name: " + recipeDescriptor.getName());
-            getLog().info("    Display name: " + recipeDescriptor.getDisplayName());
-            getLog().info("    Description: " + recipeDescriptor.getDescription());
+            getLog().info(indent(1, "Name: " + recipeDescriptor.getName()));
+            getLog().info(indent(1, "Display name: " + recipeDescriptor.getDisplayName()));
+            getLog().info(indent(1, "Description: " + recipeDescriptor.getDescription()));
             if (!recipeDescriptor.getTags().isEmpty()) {
-                getLog().info("    Tags: " + String.join(",", recipeDescriptor.getTags()));
+                getLog().info(indent(1, "Tags: " + String.join(",", recipeDescriptor.getTags())));
             }
         } else {
-            getLog().info("    " + recipeDescriptor.getName());
+            getLog().info(indent(1, recipeDescriptor.getName()));
         }
         if (!recipeDescriptor.getOptions().isEmpty()) {
             if (verbose) {
-                getLog().info("    Options:");
+                getLog().info(indent(1, "Options:"));
             }
             for (OptionDescriptor optionDescriptor : recipeDescriptor.getOptions()) {
                 StringBuilder optionBuilder = new StringBuilder(optionDescriptor.getName())
@@ -95,20 +95,20 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
                 if (optionDescriptor.isRequired()) {
                     optionBuilder.append("!");
                 }
-                getLog().info("        " + optionBuilder);
+                getLog().info(indent(2, optionBuilder));
                 if (verbose) {
-                    getLog().info("        Display name: " + optionDescriptor.getDisplayName());
-                    getLog().info("        Description: " + optionDescriptor.getDescription());
+                    getLog().info(indent(2, "Display name: " + optionDescriptor.getDisplayName()));
+                    getLog().info(indent(2, "Description: " + optionDescriptor.getDescription()));
                     getLog().info("");
                 }
             }
         }
         if (!recipeDescriptor.getRecipeList().isEmpty()) {
             if (verbose) {
-                getLog().info("    Recipe list:");
+                getLog().info(indent(1, "Recipe list:"));
             }
             for (RecipeDescriptor r : recipeDescriptor.getRecipeList()) {
-                logNestedRecipeDescriptor(r, verbose, recursive, "        ");
+                logNestedRecipeDescriptor(r, verbose, recursive, 2);
             }
             if (verbose) {
                 getLog().info("");
@@ -119,23 +119,23 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
         }
     }
 
-    private void logNestedRecipeDescriptor(RecipeDescriptor recipeDescriptor, boolean verbose, boolean recursive, String indent) {
+    private void logNestedRecipeDescriptor(RecipeDescriptor recipeDescriptor, boolean verbose, boolean recursive, int indent) {
         if (verbose) {
-            getLog().info(indent + "Name: " + recipeDescriptor.getName());
-            getLog().info(indent + "Display name: " + recipeDescriptor.getDisplayName());
-            getLog().info(indent + "Description: " + recipeDescriptor.getDescription());
+            getLog().info(indent(indent, "Name: " + recipeDescriptor.getName()));
+            getLog().info(indent(indent, "Display name: " + recipeDescriptor.getDisplayName()));
+            getLog().info(indent(indent, "Description: " + recipeDescriptor.getDescription()));
             if (!recipeDescriptor.getTags().isEmpty()) {
-                getLog().info(indent + "Tags: " + String.join(",", recipeDescriptor.getTags()));
+                getLog().info(indent(indent, "Tags: " + String.join(",", recipeDescriptor.getTags())));
             }
         } else {
-            getLog().info(indent + recipeDescriptor.getName());
+            getLog().info(indent(indent, recipeDescriptor.getName()));
         }
         if (!recipeDescriptor.getOptions().isEmpty()) {
             if (verbose) {
-                getLog().info(indent + "Options:");
+                getLog().info(indent(indent, "Options:"));
             }
             for (OptionDescriptor optionDescriptor : recipeDescriptor.getOptions()) {
-                getLog().info(indent + "    " + optionDescriptor.getName() + ": " + optionDescriptor.getValue());
+                getLog().info(indent(indent + 1, optionDescriptor.getName() + ": " + optionDescriptor.getValue()));
             }
             if (verbose) {
                 getLog().info("");
@@ -143,10 +143,10 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
         }
         if (recursive && !recipeDescriptor.getRecipeList().isEmpty()) {
             if (verbose) {
-                getLog().info(indent + "Recipe list:");
+                getLog().info(indent(indent, "Recipe list:"));
             }
             for (RecipeDescriptor nestedRecipeDescriptor : recipeDescriptor.getRecipeList()) {
-                logNestedRecipeDescriptor(nestedRecipeDescriptor, verbose, true, indent + "    ");
+                logNestedRecipeDescriptor(nestedRecipeDescriptor, verbose, true, indent + 1);
             }
             if (verbose) {
                 getLog().info("");


### PR DESCRIPTION
Pulled this snip out of of https://github.com/openrewrite/rewrite-maven-plugin/pull/150 this enables a way to do log printing with hierarchical levels with leftmost indent printing. This'll have value for a few other changes when printing out `usage`, `tree`, debug info, etc.