### PR TITLE
Configurable failOnDryRunResults

### DIFF
--- a/src/main/java/org/openrewrite/maven/RewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDryRunMojo.java
@@ -37,6 +37,12 @@ public class RewriteDryRunMojo extends AbstractRewriteMojo {
     @Parameter(property = "reportOutputDirectory", defaultValue = "${project.reporting.outputDirectory}/rewrite")
     private File reportOutputDirectory;
 
+    /**
+     * Whether to throw an exception if there are any result changes produced.
+     */
+    @Parameter(property = "failOnDryRunResults", defaultValue = "false")
+    private boolean failOnDryRunResults;
+
     @Override
     public void execute() throws MojoExecutionException {
         ResultsContainer results = listResults();
@@ -96,6 +102,10 @@ public class RewriteDryRunMojo extends AbstractRewriteMojo {
             getLog().warn("Report available:");
             getLog().warn(indent(1, patchFile.normalize().toString()));
             getLog().warn("Run 'mvn rewrite:run' to apply the recipes.");
+
+            if (failOnDryRunResults) {
+                throw new MojoExecutionException("Result changes detected. Please see result file for more information.");
+            }
         }
     }
 }

--- a/src/main/java/org/openrewrite/maven/RewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDryRunMojo.java
@@ -104,7 +104,7 @@ public class RewriteDryRunMojo extends AbstractRewriteMojo {
             getLog().warn("Run 'mvn rewrite:run' to apply the recipes.");
 
             if (failOnDryRunResults) {
-                throw new MojoExecutionException("Result changes detected. Please see result file for more information.");
+                throw new MojoExecutionException("Applying recipes would make changes. See logs for more details.");
             }
         }
     }

--- a/src/test/java/org/openrewrite/maven/RewriteDryRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDryRunIT.java
@@ -18,7 +18,7 @@ public class RewriteDryRunIT {
                 .out()
                 .error()
                 .matches(logLines ->
-                        logLines.stream().anyMatch(logLine -> logLine.contains("Result changes detected"))
+                        logLines.stream().anyMatch(logLine -> logLine.contains("Applying recipes would make changes"))
                 );
     }
 

--- a/src/test/java/org/openrewrite/maven/RewriteDryRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDryRunIT.java
@@ -12,6 +12,17 @@ import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
 public class RewriteDryRunIT {
 
     @MavenTest
+    void fail_on_dry_run(MavenExecutionResult result) {
+        assertThat(result)
+                .isFailure()
+                .out()
+                .error()
+                .matches(logLines ->
+                        logLines.stream().anyMatch(logLine -> logLine.contains("Result changes detected"))
+                );
+    }
+
+    @MavenTest
     void multi_module_project(MavenExecutionResult result) {
         assertThat(result)
                 .isSuccessful()

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/fail_on_dry_run/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/fail_on_dry_run/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>fail_on_dry_run</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>RewriteDryRunIT#fail_on_dry_run</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>org.openrewrite.java.format.AutoFormat</recipe>
+                    </activeRecipes>
+                    <failOnDryRunResults>true</failOnDryRunResults>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/fail_on_dry_run/src/main/java/sample/BadSpacing.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/fail_on_dry_run/src/main/java/sample/BadSpacing.java
@@ -1,0 +1,21 @@
+package sample;
+
+public class BadSpacing {
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}


### PR DESCRIPTION
closes openrewrite/rewrite-maven-plugin#139

Maven equivalent to https://github.com/openrewrite/rewrite-gradle-plugin/pull/52

```xml
...
<configuration>
    <failOnDryRunResults>true</failOnDryRunResults>
</configuration>
...
```