### PR TITLE
Change discover display based on feedback and current reference documentation layout

### DIFF
--- a/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
@@ -8,7 +8,6 @@ import org.codehaus.plexus.components.interactivity.Prompter;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.OptionDescriptor;
 import org.openrewrite.config.RecipeDescriptor;
-import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.maven.ui.RecipeDescriptorTreePrompter;
 import org.openrewrite.style.NamedStyles;
@@ -110,7 +109,7 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
             if (verbose) {
                 getLog().info(indent(indentLevel, rd.getDisplayName()));
                 getLog().info(indent(indentLevel + 1, rd.getName()));
-                if (!StringUtils.isNullOrEmpty(rd.getDescription())) {
+                if (rd.getDescription() != null && !rd.getDescription().isEmpty()) {
                     getLog().info(indent(indentLevel + 1, rd.getDescription()));
                 }
 
@@ -118,7 +117,7 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
                     getLog().info(indent(indentLevel, "options: "));
                     for (OptionDescriptor od : rd.getOptions()) {
                         getLog().info(indent(indentLevel + 1, od.getName() + ": " + od.getType() + (od.isRequired() ? "!" : "")));
-                        if (!StringUtils.isNullOrEmpty(od.getDescription())) {
+                        if (od.getDescription() != null && !od.getDescription().isEmpty()) {
                             getLog().info(indent(indentLevel + 2, od.getDescription()));
                         }
                     }

--- a/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
@@ -8,6 +8,7 @@ import org.codehaus.plexus.components.interactivity.Prompter;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.OptionDescriptor;
 import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.maven.ui.RecipeDescriptorTreePrompter;
 import org.openrewrite.style.NamedStyles;
@@ -81,16 +82,19 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
             writeRecipeDescriptor(recipeDescriptor, detail, 0, 1);
         }
 
+        getLog().info(indent(0, ""));
         getLog().info(indent(0, "Available Styles:"));
         for (NamedStyles style : availableStyles) {
-            getLog().info(indent(1, "name: " + style.getName()));
+            getLog().info(indent(1, style.getName()));
         }
 
+        getLog().info(indent(0, ""));
         getLog().info(indent(0, "Active Styles:"));
         for (String activeStyle : activeStyles) {
             getLog().info(indent(1, activeStyle));
         }
 
+        getLog().info(indent(0, ""));
         getLog().info(indent(0, "Active Recipes:"));
         for (RecipeDescriptor recipeDescriptor : activeRecipeDescriptors) {
             writeRecipeDescriptor(recipeDescriptor, detail, 0, 1);
@@ -103,20 +107,25 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
 
     private void writeRecipeDescriptor(RecipeDescriptor rd, boolean verbose, int currentRecursionLevel, int indentLevel) {
         if (currentRecursionLevel <= recursion) {
-            getLog().info(indent(indentLevel, "name: " + rd.getName()));
             if (verbose) {
-                getLog().info(indent(indentLevel, "displayName: " + rd.getDisplayName()));
-                getLog().info(indent(indentLevel, "description: " + rd.getDescription()));
-
-                getLog().info(indent(indentLevel, "options: " + (rd.getOptions().isEmpty() ? "[]" : "")));
-                for (OptionDescriptor od : rd.getOptions()) {
-                    getLog().info(indent(indentLevel + 1, od.getName() + ": " + od.getType() + (od.isRequired() ? "!" : "")));
-                    getLog().info(indent(indentLevel + 2, "displayName: " + od.getDisplayName()));
-                    getLog().info(indent(indentLevel + 2, "description: " + od.getDescription()));
-                    getLog().info(indent(indentLevel + 2, (od.getExample() == null ? "" : "example: " + od.getExample())));
+                getLog().info(indent(indentLevel, rd.getDisplayName()));
+                getLog().info(indent(indentLevel + 1, rd.getName()));
+                if (!StringUtils.isNullOrEmpty(rd.getDescription())) {
+                    getLog().info(indent(indentLevel + 1, rd.getDescription()));
                 }
-            }
 
+                if (!rd.getOptions().isEmpty()) {
+                    getLog().info(indent(indentLevel, "options: "));
+                    for (OptionDescriptor od : rd.getOptions()) {
+                        getLog().info(indent(indentLevel + 1, od.getName() + ": " + od.getType() + (od.isRequired() ? "!" : "")));
+                        if (!StringUtils.isNullOrEmpty(od.getDescription())) {
+                            getLog().info(indent(indentLevel + 2, od.getDescription()));
+                        }
+                    }
+                }
+            } else {
+                getLog().info(indent(indentLevel, rd.getName()));
+            }
 
             if (!rd.getRecipeList().isEmpty() && (currentRecursionLevel + 1 <= recursion)) {
                 getLog().info(indent(indentLevel, "recipeList:"));

--- a/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
@@ -25,12 +25,6 @@ public class RewriteDiscoverIT {
                     .out()
                     .info()
                     .matches(logLines ->
-                            logLines.stream().anyMatch(logLine -> logLine.contains("displayName"))
-                    )
-                    .matches(logLines ->
-                            logLines.stream().anyMatch(logLine -> logLine.contains("description"))
-                    )
-                    .matches(logLines ->
                             logLines.stream().anyMatch(logLine -> logLine.contains("options"))
                     );
 


### PR DESCRIPTION
change looks like:
<img width="441" alt="now" src="https://user-images.githubusercontent.com/5619476/117356440-5711eb00-ae79-11eb-8c1c-f7b56bf33229.png">

was previously:
<img width="575" alt="previously" src="https://user-images.githubusercontent.com/5619476/117356450-5bd69f00-ae79-11eb-8258-fd51145ba18d.png">

based off feedback and on reference pages:
https://docs.openrewrite.org/reference/recipes/maven/managedependencies

<img width="786" alt="Screen Shot 2021-05-06 at 2 44 16 PM" src="https://user-images.githubusercontent.com/5619476/117356598-8b85a700-ae79-11eb-9ba7-2f6109353c78.png">
