### PR TITLE
Fix Resource File Filter

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -325,7 +325,7 @@ public abstract class AbstractRewriteMojo extends AbstractMojo {
         File file = new File(resource.getDirectory());
         if (file.exists()) {
             BiPredicate<Path, BasicFileAttributes> predicate = (p, bfa) ->
-                    bfa.isRegularFile() && Stream.of("yml", "yaml").anyMatch(type -> p.getFileName().toString().endsWith(type));
+                    bfa.isRegularFile() && Stream.of("yml", "yaml", "properties", "xml").anyMatch(type -> p.getFileName().toString().endsWith(type));
             try {
                 Files.find(file.toPath(), 999, predicate).forEach(resources::add);
             } catch (IOException e) {


### PR DESCRIPTION
Resource File Filter was ignoring properties and xml files. Added those file type so that recipe can run on those files.