### PR TITLE
Remove `scanClassPath` from the AbstractRewriteMojo EnvironmentBuilder.

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -90,9 +90,6 @@ public abstract class AbstractRewriteMojo extends AbstractMojo {
         Environment.Builder env = Environment
                 .builder(project.getProperties())
                 .scanRuntimeClasspath()
-                .scanClasspath(project.getArtifacts().stream()
-                        .map(d -> d.getFile().toPath())
-                        .collect(toList()))
                 .scanUserHome();
 
         Path absoluteConfigLocation = Paths.get(configLocation);


### PR DESCRIPTION
Remove `scanClassPath` from the AbstractRewriteMojo per
https://github.com/openrewrite/rewrite/commit/072eed5505af7a3d9175d3f63e85393c4da893dd