### PR TITLE
Set default release policy to bump next development version using minor version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,19 @@
                 <configuration>
                     <releaseProfiles>release</releaseProfiles>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
+                    <!-- "SemVerVersionPolicy" causes maven-release to increment the MINOR version when calculating the next development version. -->
+                    <!-- For example, if the current version is 4.6.3-SNAPSHOT, then we release, this will release 4.6.3, then set the next development version to 4.7.0-SNAPSHOT -->
+                    <!-- By contrast, the "default" policy increments the PATCH version. -->
+                    <projectVersionPolicyId>SemVerVersionPolicy</projectVersionPolicyId>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <!-- needed only for the SemVerVersionPolicy policy -->
+                        <groupId>org.apache.maven.release</groupId>
+                        <artifactId>maven-release-semver-policy</artifactId>
+                        <version>${maven-release-plugin.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <!-- testing-related plugins -->


### PR DESCRIPTION
In lieu of having release versions dynamically deduced from `git tag`s, when performing a release, set the default policy be to bump the `minor` version when going to the next development version.

Note, if wanting to release a patch version, you can manually set the version to being `desiredVersion-SNAPSHOT`, e.g. `4.6.5-SNAPSHOT` would release `4.6.5`, but the key point here is that by default, the _next development version_ would bump the minor version. So, for example, releasing on `4.6.5-SNAPSHOT` would release `4.6.5`, then bump the development version to `4.7.0-SNAPSHOT`. Currently, using the default strategy, it would bump the version to `4.6.6-SNAPSHOT`. It's more likely we're wanting to bump the next version to the next-highest minor version than patch.