### PR TITLE
Have skipMavenParsing be a declared parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,7 @@
                     <plugin>
                         <groupId>org.openrewrite.maven</groupId>
                         <artifactId>rewrite-maven-plugin</artifactId>
-                        <version>4.13.0</version>
+                        <version>4.16.0</version>
                         <configuration>
                             <activeRecipes>
                                 <recipe>org.openrewrite.java.format.AutoFormat</recipe>

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -162,7 +162,7 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
                 }
             }
             ExecutionContext ctx = executionContext();
-            MavenMojoProjectParser projectParser = new MavenMojoProjectParser(getLog(), baseDir, pomCacheEnabled, pomCacheDirectory, project, runtime, getExclusions());
+            MavenMojoProjectParser projectParser = new MavenMojoProjectParser(getLog(), baseDir, pomCacheEnabled, pomCacheDirectory, project, runtime, skipMavenParsing, getExclusions());
             List<SourceFile> sourceFiles = projectParser.listSourceFiles(styles, ctx);
 
             getLog().info("Running recipe(s)...");

--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -49,6 +49,13 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
   @Parameter(property = "rewrite.pomCacheDirectory", alias = "pomCacheDirectory")
   protected String pomCacheDirectory;
 
+  /**
+   * When enabled, skip parsing Maven `pom.xml`s, and any transitive poms, as source files.
+   * This can be an efficiency improvement in certain situations.
+   */
+  @Parameter(property = "skipMavenParsing", defaultValue = "false")
+  protected boolean skipMavenParsing;
+
   @Nullable
   @Parameter(property = "rewrite.checkstyleConfigFile", alias = "checkstyleConfigFile")
   protected String checkstyleConfigFile;

--- a/src/main/java/org/openrewrite/maven/CycloneDxBomMojo.java
+++ b/src/main/java/org/openrewrite/maven/CycloneDxBomMojo.java
@@ -31,7 +31,7 @@ public class CycloneDxBomMojo extends AbstractRewriteMojo {
     public void execute() throws MojoExecutionException {
         ExecutionContext ctx = executionContext();
         Path baseDir = getBaseDir();
-        Maven maven = new MavenMojoProjectParser(getLog(), baseDir, pomCacheEnabled, pomCacheDirectory, project, runtime, getExclusions()).parseMaven(ctx);
+        Maven maven = new MavenMojoProjectParser(getLog(), baseDir, pomCacheEnabled, pomCacheDirectory, project, runtime, skipMavenParsing, getExclusions()).parseMaven(ctx);
         if(maven != null) {
             File cycloneDxBom = buildCycloneDxBom(maven);
             projectHelper.attachArtifact(project, "xml", "cyclonedx", cycloneDxBom);

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -43,14 +43,16 @@ public class MavenMojoProjectParser {
     private final List<Marker> projectProvenance;
     private final boolean pomCacheEnabled;
     @Nullable private final String pomCacheDirectory;
+    private final boolean skipMavenParsing;
     private final Collection<String> exclusions;
 
-    public MavenMojoProjectParser(Log logger, Path baseDir, boolean pomCacheEnabled, @Nullable String pomCacheDirectory, MavenProject mavenProject, RuntimeInformation runtime, Collection<String> exclusions) {
+    public MavenMojoProjectParser(Log logger, Path baseDir, boolean pomCacheEnabled, @Nullable String pomCacheDirectory, MavenProject mavenProject, RuntimeInformation runtime, boolean skipMavenParsing, Collection<String> exclusions) {
         this.logger = logger;
         this.baseDir = baseDir;
         this.mavenProject = mavenProject;
         this.pomCacheEnabled = pomCacheEnabled;
         this.pomCacheDirectory = pomCacheDirectory;
+        this.skipMavenParsing = skipMavenParsing;
         this.exclusions = exclusions;
 
         String javaRuntimeVersion = System.getProperty("java.runtime.version");
@@ -92,7 +94,8 @@ public class MavenMojoProjectParser {
 
     @Nullable
     public Maven parseMaven(ExecutionContext ctx) {
-        if(System.getProperty("skipMavenParsing") != null) {
+        if(skipMavenParsing) {
+            logger.info("Skipping Maven parsing...");
             return null;
         }
 


### PR DESCRIPTION
this way:
- it shows up in helpdoc, 
- it's easier to be aware of the configuration parameter at all
- when it's declared as a Paramter, it can be configured within the pom.xml itself as a configuration field, e.g. `<skipMavenParsing>` in `<configuration>` under rewrite-maven-plugin

Kept the reference as `skipMavenParsing` in order to be backwards compatible with `-DskipMavenParsing`, vs. having this be referenced on the CLI as `-Drewrite.skipMavenParsing`

Inspired by https://github.com/openrewrite/rewrite-maven-plugin/issues/238