### PR TITLE
Rework MavenMojoProjectParser to use SourceSet from parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </scm>
 
     <properties>
-        <rewrite.version>7.16.0</rewrite.version>
+        <rewrite.version>7.17.0-SNAPSHOT</rewrite.version>
 
         <!-- using 'ssh' url scheme by default, which assumes a human is performing git operations leveraging an ssh key -->
         <developerConnectionUrl>scm:git:ssh://git@github.com/openrewrite/rewrite-maven-plugin.git</developerConnectionUrl>
@@ -188,13 +188,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.2</version>
+            <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.7.2</version>
+            <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -203,7 +203,7 @@ public class MavenMojoProjectParser {
         //Any resources parsed from "main/resources" should also have the main source set added to them.
         sourceFiles.addAll(ListUtils.map(
                 rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/main/resources"), alreadyParsed),
-                addProvenance(baseDir, mainProvenance,null)));
+                addProvenance(baseDir, mainProvenance, null)));
 
         logger.info("Parsing Java test files...");
         List<Path> testDependencies = mavenProject.getTestClasspathElements().stream()

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -195,12 +195,12 @@ public class MavenMojoProjectParser {
             sourceFiles.add(maven);
             alreadyParsed.add(maven.getSourcePath());
         }
-        //JavaParser will add SourceSet Markers to any Java SourceFile, so only adding the project provenance info to
-        //java source.
+        // JavaParser will add SourceSet Markers to any Java SourceFile, so only adding the project provenance info to
+        // java source.
         sourceFiles.addAll(ListUtils.map(javaParser.parse(mainJavaSources, baseDir, ctx),
                 addProvenance(baseDir, projectProvenance, generatedSourcePaths)));
         ResourceParser rp = new ResourceParser(logger, exclusions);
-        //Any resources parsed from "main/resources" should also have the main source set added to them.
+        // Any resources parsed from "main/resources" should also have the main source set added to them.
         sourceFiles.addAll(ListUtils.map(
                 rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/main/resources"), alreadyParsed),
                 addProvenance(baseDir, mainProvenance, null)));
@@ -216,12 +216,12 @@ public class MavenMojoProjectParser {
         List<Marker> testProvenance = new ArrayList<>(projectProvenance);
         testProvenance.add(javaParser.getSourceSet(ctx));
 
-        //JavaParser will add SourceSet Markers to any Java SourceFile, so only adding the project provenance info to
-        //java source.
+        // JavaParser will add SourceSet Markers to any Java SourceFile, so only adding the project provenance info to
+        // java source.
         sourceFiles.addAll(ListUtils.map(
                 javaParser.parse(listJavaSources(mavenProject.getBuild().getTestSourceDirectory()), baseDir, ctx),
                 addProvenance(baseDir, projectProvenance, null) ));
-        //Any resources parsed from "test/resources" should also have the test source set added to them.
+        // Any resources parsed from "test/resources" should also have the test source set added to them.
         sourceFiles.addAll(ListUtils.map(
                 rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/test/resources"), alreadyParsed),
                 addProvenance(baseDir, testProvenance, null)));

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -195,9 +195,12 @@ public class MavenMojoProjectParser {
             sourceFiles.add(maven);
             alreadyParsed.add(maven.getSourcePath());
         }
+        //JavaParser will add SourceSet Markers to any Java SourceFile, so only adding the project provenance info to
+        //java source.
         sourceFiles.addAll(ListUtils.map(javaParser.parse(mainJavaSources, baseDir, ctx),
-                addProvenance(baseDir, mainProvenance, generatedSourcePaths)));
+                addProvenance(baseDir, projectProvenance, generatedSourcePaths)));
         ResourceParser rp = new ResourceParser(logger, exclusions);
+        //Any resources parsed from "main/resources" should also have the main source set added to them.
         sourceFiles.addAll(ListUtils.map(
                 rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/main/resources"), alreadyParsed),
                 addProvenance(baseDir, mainProvenance,null)));
@@ -213,9 +216,12 @@ public class MavenMojoProjectParser {
         List<Marker> testProvenance = new ArrayList<>(projectProvenance);
         testProvenance.add(javaParser.getSourceSet(ctx));
 
+        //JavaParser will add SourceSet Markers to any Java SourceFile, so only adding the project provenance info to
+        //java source.
         sourceFiles.addAll(ListUtils.map(
                 javaParser.parse(listJavaSources(mavenProject.getBuild().getTestSourceDirectory()), baseDir, ctx),
-                addProvenance(baseDir, testProvenance, null) ));
+                addProvenance(baseDir, projectProvenance, null) ));
+        //Any resources parsed from "test/resources" should also have the test source set added to them.
         sourceFiles.addAll(ListUtils.map(
                 rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/test/resources"), alreadyParsed),
                 addProvenance(baseDir, testProvenance, null)));


### PR DESCRIPTION
Refactored MavenMojoProjectParser to be compatible with the changes made to rewrite-7.17.0. Specifically, the `SourceSet` provenance information is now managed by the JavaParser. The project parser now uses the SourceSet markers from the JavaParser.