### PR TITLE
Add integration tests for init and configure mojos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <phase>compile</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>javadoc</goal>
                             <goal>jar</goal>
@@ -320,7 +320,7 @@
                 <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
-                        <phase>compile</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>aggregate</goal>
                             <goal>jar</goal>

--- a/src/main/java/org/openrewrite/maven/InitMojo.java
+++ b/src/main/java/org/openrewrite/maven/InitMojo.java
@@ -13,7 +13,11 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Mojo(name = "init", threadSafe = true)
@@ -53,6 +57,7 @@ public class InitMojo extends AbstractRewriteMojo {
     public void execute() throws MojoExecutionException {
         Path baseDir = getBaseDir();
         if(rootOnly && !project.getBasedir().toPath().equals(baseDir)) {
+            getLog().warn("Skipping non-root project " + project.getFile().getPath());
             return;
         }
         ExecutionContext ctx = executionContext();

--- a/src/test/java/org/openrewrite/maven/ConfigureMojoIT.java
+++ b/src/test/java/org/openrewrite/maven/ConfigureMojoIT.java
@@ -1,0 +1,31 @@
+package org.openrewrite.maven;
+
+import com.soebes.itf.jupiter.extension.MavenGoal;
+import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
+import com.soebes.itf.jupiter.extension.MavenTest;
+import com.soebes.itf.jupiter.extension.SystemProperties;
+import com.soebes.itf.jupiter.extension.SystemProperty;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+
+import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
+
+@MavenJupiterExtension
+@MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:configure")
+@SystemProperties({
+        @SystemProperty(value = "activeRecipes", content = "org.openrewrite.java.testing.junit5.ParameterizedRunnerToParameterized"),
+        @SystemProperty(value = "dependencies", content = "org.openrewrite.recipe:rewrite-spring:4.14.1")
+})
+public class ConfigureMojoIT {
+
+    @MavenTest
+    void single_project(MavenExecutionResult result) {
+        assertThat(result)
+                .isSuccessful()
+                .out()
+                .info()
+                .matches(logLines -> logLines.stream()
+                        .anyMatch(logLine -> logLine.contains("Added rewrite-maven-plugin to")),
+                        "Logs success message");
+    }
+
+}

--- a/src/test/java/org/openrewrite/maven/InitMojoIT.java
+++ b/src/test/java/org/openrewrite/maven/InitMojoIT.java
@@ -1,0 +1,32 @@
+package org.openrewrite.maven;
+
+import com.soebes.itf.jupiter.extension.MavenGoal;
+import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
+import com.soebes.itf.jupiter.extension.MavenTest;
+import com.soebes.itf.jupiter.extension.SystemProperties;
+import com.soebes.itf.jupiter.extension.SystemProperty;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+
+import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
+
+@MavenJupiterExtension
+@MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:init")
+@SystemProperties({
+        @SystemProperty(value = "activeRecipes", content = "org.openrewrite.java.testing.junit5.ParameterizedRunnerToParameterized"),
+        @SystemProperty(value = "dependencies", content = "<dependencies><dependency><groupId>org.openrewrite.recipe</groupId><artifactId>rewrite-spring</artifactId><version>4.14.1</version></dependency></dependencies>"),
+        @SystemProperty(value = "rootOnly", content = "false")
+})
+public class InitMojoIT {
+
+    @MavenTest
+    void single_project(MavenExecutionResult result) {
+        assertThat(result)
+                .isSuccessful()
+                .out()
+                .info()
+                .matches(logLines -> logLines.stream()
+                        .anyMatch(logLine -> logLine.contains("Added rewrite-maven-plugin to")),
+                        "Logs success message");
+    }
+
+}

--- a/src/test/resources-its/org/openrewrite/maven/ConfigureMojoIT/single_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/ConfigureMojoIT/single_project/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>single_project</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>ConfigureMojoIT#single_project</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>org.openrewrite.java.format.AutoFormat</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources-its/org/openrewrite/maven/InitMojoIT/single_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/InitMojoIT/single_project/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>single_project</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>InitMojoIT#single_project</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>


### PR DESCRIPTION
Was playing around with these locally, and noticed they each take a differently formatted `dependencies` argument, which isn't immediately clear from the outset. It's due to on the one hand `AddPlugin` in `init`, versus `ChangePluginDependencies` in `configure`. Having tests that verify and highlight these differences should help discoverability.

I'd even be inclined to change most likely the `init` mojo to use the gav form of dependencies used in `configure`. I guess that could be achieved by also using `.doNext(new ChangePluginDependencies(groupId, artifactId, dependencies))` in `init` instead of adding the dependencies through `AddPlugin`. What would you say to such a suggested change?

Also added a log statement as inexplicably (for me) the InitMojoIT silently ignored the mojo run, leaving me puzzled.
And I delay the maven source and javadoc plugins to be able to run `mvn test -Dtest=InitMojoIT` quicker locally.
Let me know if either of these changes should be reverted! :)