### PR TITLE
Add fail-at-end flags to provide better info per test-run in the event of failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,4 @@ jobs:
           java-version: 11
           cache: maven
       - name: build
-        if: github.event_name != 'workflow_dispatch'
-        run: ./mvnw --no-transfer-progress -B clean verify -DskipITs --file pom.xml
-      - name: verify
-        if: github.event_name != 'push'
-        run: ./mvnw --no-transfer-progress -B clean verify --file pom.xml
+        run: ./mvnw --show-version --no-transfer-progress clean verify --file=pom.xml --fail-at-end --batch-mode

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
           git config user.name "github-actions[bot]"
 
       - name: publish-release
-        run: ./mvnw --settings=${{ github.workspace }}/settings.xml --file=pom.xml --activate-profiles=release,release-automation --batch-mode help:active-profiles release:prepare release:perform
+        run: ./mvnw --show-version --settings=${{ github.workspace }}/settings.xml --file=pom.xml --activate-profiles=release,release-automation help:active-profiles release:prepare release:perform --batch-mode
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONATYPE_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -37,6 +37,6 @@ jobs:
 
       - name: rollback
         if: ${{ failure() }}
-        run: ./mvnw --settings=${{github.workspace}}/settings.xml --file=pom.xml --activate-profiles=release,release-automation --batch-mode help:active-profiles release:rollback
+        run: ./mvnw --show-version --settings=${{github.workspace}}/settings.xml --file=pom.xml --activate-profiles=release,release-automation help:active-profiles release:rollback --batch-mode
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/src/test/java/org/openrewrite/maven/InitMojoIT.java
+++ b/src/test/java/org/openrewrite/maven/InitMojoIT.java
@@ -25,9 +25,7 @@ public class InitMojoIT {
                 .isSuccessful()
                 .out()
                 .info()
-                .matches(logLines -> logLines.stream()
-                        .anyMatch(logLine -> logLine.contains("Added rewrite-maven-plugin to")),
-                        "Logs success message");
+                .anySatisfy(line -> assertThat(line).contains("Added rewrite-maven-plugin to"));
     }
 
 }

--- a/src/test/java/org/openrewrite/maven/RemoveMojoIT.java
+++ b/src/test/java/org/openrewrite/maven/RemoveMojoIT.java
@@ -18,9 +18,7 @@ public class RemoveMojoIT {
                 .isSuccessful()
                 .out()
                 .info()
-                .matches(logLines ->
-                        logLines.stream().anyMatch(logLine -> logLine.contains("Removed rewrite-maven-plugin from"))
-                );
+                .anySatisfy(line -> assertThat(line).contains("Removed rewrite-maven-plugin from"));
     }
 
 }

--- a/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
@@ -25,9 +25,7 @@ public class RewriteDiscoverIT {
                     .isSuccessful()
                     .out()
                     .info()
-                    .matches(logLines ->
-                            logLines.stream().anyMatch(logLine -> logLine.contains("options"))
-                    );
+                    .anySatisfy(line -> assertThat(line).contains("options"));
 
             assertThat(result).out().warn().isEmpty();
         }
@@ -39,9 +37,7 @@ public class RewriteDiscoverIT {
                     .isSuccessful()
                     .out()
                     .info()
-                    .matches(logLines ->
-                            logLines.stream().anyMatch(logLine -> logLine.contains("org.openrewrite.java.format.AutoFormat"))
-                    );
+                    .anySatisfy(line -> assertThat(line).contains("org.openrewrite.java.format.AutoFormat"));
         }
 
         @MavenTest
@@ -51,9 +47,7 @@ public class RewriteDiscoverIT {
                     .isSuccessful()
                     .out()
                     .info()
-                    .matches(logLines ->
-                            logLines.stream().anyMatch(logLine -> logLine.contains("recipeList"))
-                    );
+                    .anySatisfy(line -> assertThat(line).contains("recipeList"));
 
             assertThat(result).out().warn().isEmpty();
         }
@@ -81,9 +75,7 @@ public class RewriteDiscoverIT {
                 .isSuccessful()
                 .out()
                 .info()
-                .matches(logLines ->
-                        logLines.stream().anyMatch(logLine -> logLine.contains("com.example.RewriteDiscoverIT.CodeCleanup"))
-                );
+                .anySatisfy(line -> assertThat(line).contains("com.example.RewriteDiscoverIT.CodeCleanup"));
 
         assertThat(result).out().warn().isEmpty();
     }

--- a/src/test/java/org/openrewrite/maven/RewriteDryRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDryRunIT.java
@@ -18,9 +18,7 @@ public class RewriteDryRunIT {
                 .isFailure()
                 .out()
                 .error()
-                .matches(logLines ->
-                        logLines.stream().anyMatch(logLine -> logLine.contains("Applying recipes would make changes"))
-                );
+                .anySatisfy(line -> assertThat(line).contains("Applying recipes would make changes"));
     }
 
     @MavenTest
@@ -29,9 +27,7 @@ public class RewriteDryRunIT {
                 .isSuccessful()
                 .out()
                 .warn()
-                .matches(logLines ->
-                        logLines.stream().anyMatch(logLine -> logLine.contains("org.openrewrite.java.cleanup.FinalizeLocalVariables"))
-                );
+                .anySatisfy(line -> assertThat(line).contains("org.openrewrite.java.cleanup.FinalizeLocalVariables"));
     }
 
     @MavenTest
@@ -40,9 +36,7 @@ public class RewriteDryRunIT {
                 .isSuccessful()
                 .out()
                 .warn()
-                .matches(logLines ->
-                        logLines.stream().anyMatch(logLine -> logLine.contains("org.openrewrite.java.format.AutoFormat"))
-                );
+                .anySatisfy(line -> assertThat(line).contains("org.openrewrite.java.format.AutoFormat"));
     }
 
 }

--- a/src/test/java/org/openrewrite/maven/RewriteRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunIT.java
@@ -21,9 +21,7 @@ public class RewriteRunIT {
                 .isSuccessful()
                 .out()
                 .warn()
-                .matches(logLines ->
-                        logLines.stream().anyMatch(logLine -> logLine.contains("org.openrewrite.java.cleanup.FinalizeLocalVariables"))
-                );
+                .anySatisfy(line -> assertThat(line).contains("org.openrewrite.java.cleanup.FinalizeLocalVariables"));
     }
 
     @MavenTest
@@ -32,9 +30,7 @@ public class RewriteRunIT {
                 .isSuccessful()
                 .out()
                 .warn()
-                .matches(logLines ->
-                        logLines.stream().anyMatch(logLine -> logLine.contains("org.openrewrite.java.format.AutoFormat"))
-                );
+                .anySatisfy(line -> assertThat(line).contains("org.openrewrite.java.format.AutoFormat"));
     }
 
 }


### PR DESCRIPTION
Test polish, leverage anySatisfy for matching single line partial contains

Add fail-at-end flags to provide better info per test-run in the event of failure