### PR TITLE
include the baseDir on the path of the maven pom if the sourcePath is `pom.xml`

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -311,7 +311,8 @@ public class MavenMojoProjectParser {
         Xml.Document maven = parseMaven(ctx);
         if (maven != null) {
             sourceFiles.add(maven);
-            alreadyParsed.add(maven.getSourcePath());
+            Path mavenPath = "pom.xml".equals(maven.getSourcePath().toString()) ? Paths.get(baseDir + File.separator + maven.getSourcePath()) : maven.getSourcePath();
+            alreadyParsed.add(mavenPath);
         }
 
         logger.info("Parsing Java main files...");


### PR DESCRIPTION
`maven.getSourcePath()` returns a Path of `pom.xml`.
Then `ResourceParser` includes the baseDir in the path of the files it looks for (`/user/.../pom.xml`).
So, `alreadyParsed` does not detect the file has been parsed and adds another `XML` without the maven marker.