### PR TITLE
Document Init, Configure and Remove Mojos for discovery through :help

### DIFF
--- a/src/main/java/org/openrewrite/maven/ConfigureMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigureMojo.java
@@ -20,6 +20,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Configure rewrite-maven-plugin (or any other plugin) in the project.<br>
+ * For example:<br>
+ * {@code ./mvnw rewrite:configure -DactiveRecipes=org.openrewrite.java.spring.boot2.SpringBoot1To2Migration -Ddependencies=org.openrewrite.recipe:rewrite-spring:4.17.0}
+ */
 @Mojo(name = "configure", threadSafe = true)
 @Execute
 @SuppressWarnings("unused")
@@ -76,7 +81,7 @@ public class ConfigureMojo extends AbstractRewriteMojo {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        getLog().info("Added " + artifactId + " to " + project.getFile().getPath());
+        getLog().info("Changed " + artifactId + " in " + project.getFile().getPath());
     }
 
     @Nullable

--- a/src/main/java/org/openrewrite/maven/InitMojo.java
+++ b/src/main/java/org/openrewrite/maven/InitMojo.java
@@ -16,6 +16,11 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * Add rewrite-maven-plugin (or any other plugin) to the project.<br>
+ * For example:<br>
+ * {@code ./mvnw rewrite:init -DactiveRecipes=org.openrewrite.java.spring.boot2.SpringBoot1To2Migration -Ddependencies=org.openrewrite.recipe:rewrite-spring:4.17.0}
+ */
 @Mojo(name = "init", threadSafe = true)
 @Execute
 @SuppressWarnings("unused")

--- a/src/main/java/org/openrewrite/maven/RemoveMojo.java
+++ b/src/main/java/org/openrewrite/maven/RemoveMojo.java
@@ -17,6 +17,11 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Remove rewrite-maven-plugin (or any other plugin) from the project.<br>
+ * For example:<br>
+ * {@code ./mvnw rewrite:remove}
+ */
 @Mojo(name = "remove", threadSafe = true)
 @Execute
 @SuppressWarnings("unused")

--- a/src/test/java/org/openrewrite/maven/ConfigureMojoIT.java
+++ b/src/test/java/org/openrewrite/maven/ConfigureMojoIT.java
@@ -21,7 +21,7 @@ public class ConfigureMojoIT {
                 .isSuccessful()
                 .out()
                 .info()
-                .anySatisfy(line -> assertThat(line).contains("Added rewrite-maven-plugin to"));
+                .anySatisfy(line -> assertThat(line).contains("Changed rewrite-maven-plugin in"));
     }
 
 }


### PR DESCRIPTION
Even though I wrote the integration tests, I still had to look up how to execute the commands again. :upside_down_face: 
Adding examples to `./mvnw org.openrewrite.maven:rewrite-maven-plugin:help` ought to help discover their usage.