### PR TITLE
Added quark parser to `ResourceParser`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </scm>
 
     <properties>
-        <rewrite.version>7.22.0</rewrite.version>
+        <rewrite.version>7.23.0-SNAPSHOT</rewrite.version>
 
         <!-- using 'ssh' url scheme by default, which assumes a human is performing git operations leveraging an ssh key -->
         <developerConnectionUrl>scm:git:ssh://git@github.com/openrewrite/rewrite-maven-plugin.git

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -344,10 +344,9 @@ public class MavenMojoProjectParser {
 
         ResourceParser rp = new ResourceParser(logger, exclusions, sizeThresholdMb);
 
-        Set<Path> quarks = new HashSet<>();
         // Any resources parsed from "main/resources" should also have the main source set added to them.
         sourceFiles.addAll(ListUtils.map(
-                rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/main/resources"), alreadyParsed, quarks),
+                rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/main/resources"), alreadyParsed),
                 addProvenance(baseDir, ListUtils.concat(projectProvenance, javaParser.getSourceSet(ctx)), null)));
 
         logger.info("Parsing Java test files...");
@@ -367,12 +366,12 @@ public class MavenMojoProjectParser {
 
         // Any resources parsed from "test/resources" should also have the test source set added to them.
         sourceFiles.addAll(ListUtils.map(
-                rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/test/resources"), alreadyParsed, quarks),
+                rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/test/resources"), alreadyParsed),
                 addProvenance(baseDir, ListUtils.concat(projectProvenance, javaParser.getSourceSet(ctx)), null)));
 
         // Parse non-java, non-resource files
         sourceFiles.addAll(ListUtils.map(
-                rp.parse(baseDir, mavenProject.getBasedir().toPath(), alreadyParsed, quarks),
+                rp.parse(baseDir, mavenProject.getBasedir().toPath(), alreadyParsed),
                 addProvenance(baseDir, projectProvenance, null)
         ));
 

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -33,13 +33,11 @@ import org.openrewrite.maven.cache.MavenPomCache;
 import org.openrewrite.maven.cache.RocksdbMavenPomCache;
 import org.openrewrite.maven.internal.RawRepositories;
 import org.openrewrite.maven.tree.ProfileActivation;
-import org.openrewrite.quark.QuarkParser;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.xml.tree.Xml;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -381,7 +381,7 @@ public class MavenMojoProjectParser {
 
         // Parse non-java, non-resource files
         sourceFiles.addAll(ListUtils.map(
-                rp.parse(mavenSession.getCurrentProject().getBasedir().toPath(), alreadyParsed),
+                rp.parse(mavenProject.getBasedir().toPath(), alreadyParsed),
                 addProvenance(baseDir, projectProvenance, null)
         ));
 

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -33,11 +33,13 @@ import org.openrewrite.maven.cache.MavenPomCache;
 import org.openrewrite.maven.cache.RocksdbMavenPomCache;
 import org.openrewrite.maven.internal.RawRepositories;
 import org.openrewrite.maven.tree.ProfileActivation;
+import org.openrewrite.quark.QuarkParser;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.xml.tree.Xml;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -344,9 +346,10 @@ public class MavenMojoProjectParser {
 
         ResourceParser rp = new ResourceParser(logger, exclusions, sizeThresholdMb);
 
+        Set<Path> quarks = new HashSet<>();
         // Any resources parsed from "main/resources" should also have the main source set added to them.
         sourceFiles.addAll(ListUtils.map(
-                rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/main/resources"), alreadyParsed),
+                rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/main/resources"), alreadyParsed, quarks),
                 addProvenance(baseDir, ListUtils.concat(projectProvenance, javaParser.getSourceSet(ctx)), null)));
 
         logger.info("Parsing Java test files...");
@@ -366,12 +369,12 @@ public class MavenMojoProjectParser {
 
         // Any resources parsed from "test/resources" should also have the test source set added to them.
         sourceFiles.addAll(ListUtils.map(
-                rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/test/resources"), alreadyParsed),
+                rp.parse(baseDir, mavenProject.getBasedir().toPath().resolve("src/test/resources"), alreadyParsed, quarks),
                 addProvenance(baseDir, ListUtils.concat(projectProvenance, javaParser.getSourceSet(ctx)), null)));
 
         // Parse non-java, non-resource files
         sourceFiles.addAll(ListUtils.map(
-                rp.parse(baseDir, mavenProject.getBasedir().toPath(), alreadyParsed),
+                rp.parse(baseDir, mavenProject.getBasedir().toPath(), alreadyParsed, quarks),
                 addProvenance(baseDir, projectProvenance, null)
         ));
 

--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -30,13 +30,13 @@ public class ResourceParser {
     public ResourceParser(Path baseDir, Log logger, Collection<String> exclusions, int sizeThresholdMb, Collection<Path> skipOtherMavenProjects) {
         this.baseDir = baseDir;
         this.logger = logger;
-        this.exclusions = mergeExclusions(baseDir, exclusions);
+        this.exclusions = mergeExclusions(exclusions);
         this.sizeThresholdMb = sizeThresholdMb;
         this.skipOtherMavenProjects = skipOtherMavenProjects;
     }
 
-    private static List<PathMatcher> mergeExclusions(Path baseDir, Collection<String> exclusions) {
-        Set<String> mergedExclusions = new HashSet<>(new ArrayList<>(Arrays.asList("build", "target", "out", ".gradle", ".idea", ".project", "node_modules", ".git", ".metadata", ".DS_Store")));
+    private List<PathMatcher> mergeExclusions(Collection<String> exclusions) {
+        Set<String> mergedExclusions = new HashSet<>(Arrays.asList("build", "target", "out", ".gradle", ".idea", ".project", "node_modules", ".git", ".metadata", ".DS_Store"));
         mergedExclusions.addAll(exclusions);
         return mergedExclusions.stream().map(o -> baseDir.getFileSystem().getPathMatcher("glob:**/" + o)).collect(Collectors.toList());
     }
@@ -91,7 +91,7 @@ public class ResourceParser {
             }
         });
 
-        List<S> sourceFiles = new ArrayList<>(resources.size());
+        List<S> sourceFiles = new ArrayList<>(resources.size() + quarkPaths.size());
 
         JsonParser jsonParser = new JsonParser();
         List<Path> jsonPaths = new ArrayList<>();

--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -14,28 +14,34 @@ import org.openrewrite.yaml.YamlParser;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ResourceParser {
+    private final Path baseDir;
     private final Log logger;
-    private final Collection<String> exclusions;
+    private final Collection<PathMatcher> exclusions;
     private final int sizeThresholdMb;
+    private final Collection<Path> skipOtherMavenProjects;
 
-    public ResourceParser(Log logger, Collection<String> exclusions, int thresholdMb) {
+    public ResourceParser(Path baseDir, Log logger, Collection<String> exclusions, int sizeThresholdMb, Collection<Path> skipOtherMavenProjects) {
+        this.baseDir = baseDir;
         this.logger = logger;
-        this.exclusions = exclusions;
-        sizeThresholdMb = thresholdMb;
+        this.exclusions = mergeExclusions(baseDir, exclusions);
+        this.sizeThresholdMb = sizeThresholdMb;
+        this.skipOtherMavenProjects = skipOtherMavenProjects;
     }
 
-    public List<SourceFile> parse(Path baseDir, Path searchDir, Collection<Path> alreadyParsed) {
+    private static List<PathMatcher> mergeExclusions(Path baseDir, Collection<String> exclusions) {
+        Set<String> mergedExclusions = new HashSet<>(new ArrayList<>(Arrays.asList("build", "target", "out", ".gradle", ".idea", ".project", "node_modules", ".git", ".metadata", ".DS_Store")));
+        mergedExclusions.addAll(exclusions);
+        return mergedExclusions.stream().map(o -> baseDir.getFileSystem().getPathMatcher("glob:**/" + o)).collect(Collectors.toList());
+    }
+
+    public List<SourceFile> parse(Path searchDir, Collection<Path> alreadyParsed) {
         List<SourceFile> sourceFiles = new ArrayList<>();
         if (!searchDir.toFile().exists()) {
             return sourceFiles;
@@ -43,125 +49,122 @@ public class ResourceParser {
         Consumer<Throwable> errorConsumer = t -> logger.error("Error parsing", t);
         InMemoryExecutionContext ctx = new InMemoryExecutionContext(errorConsumer);
 
-        sourceFiles.addAll(parseSourceFiles(baseDir, searchDir, alreadyParsed, ctx));
+        try {
+            sourceFiles.addAll(parseSourceFiles(searchDir, alreadyParsed, ctx));
+        } catch (IOException e) {
+            logger.error(e.getMessage(), e);
+            throw new UncheckedIOException(e);
+        }
         return sourceFiles;
     }
 
     @SuppressWarnings("unchecked")
     public <S extends SourceFile> List<S> parseSourceFiles(
-            Path baseDir,
             Path searchDir,
             Collection<Path> alreadyParsed,
-            ExecutionContext ctx) {
+            ExecutionContext ctx) throws IOException {
 
+        List<Path> resources = new ArrayList<>();
         List<Path> quarkPaths = new ArrayList<>();
-        try (Stream<Path> resources = Files.find(searchDir, 16, (path, attrs) -> {
-            // Prevent java files from being parsed as quarks.
-            if (path.toString().endsWith(".java")) {
-                return false;
-            }
 
-            if (alreadyParsed.contains(path)) {
-                return false;
-            }
-
-            if (attrs.isDirectory() || attrs.isSymbolicLink() || attrs.isOther() || attrs.size() == 0) {
-                return false;
-            }
-
-            for (Path pathSegment : searchDir.relativize(path)) {
-                String pathStr = pathSegment.toString();
-                if ("target".equals(pathStr) || "build".equals(pathStr) || "out".equals(pathStr) ||
-                        ".gradle".equals(pathStr) || "node_modules".equals(pathStr) || ".metadata".equals(pathStr) ||
-                        ".DS_Store".equals(pathStr) || ".git".equals(pathStr) || ".idea".equals(pathStr)) {
-                    return false;
+        Files.walkFileTree(searchDir, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                if (isIgnored(dir) || skipOtherMavenProjects.contains(dir)) {
+                    return FileVisitResult.SKIP_SUBTREE;
                 }
+                return FileVisitResult.CONTINUE;
             }
 
-            for (String exclusion : exclusions) {
-                PathMatcher matcher = baseDir.getFileSystem().getPathMatcher("glob:" + exclusion);
-                if (matcher.matches(baseDir.relativize(path))) {
-                    alreadyParsed.add(path);
-                    return false;
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                if (!attrs.isOther() && !alreadyParsed.contains(file) && !isIgnored(file)) {
+                    if (isOverSizeThreshold(attrs.size())) {
+                        logger.info("Parsing as Quark " + file + " as its size + " + attrs.size() / (1024L * 1024L) +
+                                "Mb exceeds size threshold " + sizeThresholdMb + "Mb");
+                        quarkPaths.add(file);
+                    } else {
+                        resources.add(file);
+                    }
                 }
+                return FileVisitResult.CONTINUE;
             }
+        });
 
-            long fileSize = attrs.size();
-            if ((sizeThresholdMb > 0 && fileSize > sizeThresholdMb * 1024L * 1024L)) {
-                logger.info("Parsing as Quark " + path + " as its size + " + fileSize / (1024L * 1024L) +
-                        "Mb exceeds size threshold " + sizeThresholdMb + "Mb");
+        List<S> sourceFiles = new ArrayList<>(resources.size());
+
+        JsonParser jsonParser = new JsonParser();
+        List<Path> jsonPaths = new ArrayList<>();
+
+        XmlParser xmlParser = new XmlParser();
+        List<Path> xmlPaths = new ArrayList<>();
+
+        YamlParser yamlParser = new YamlParser();
+        List<Path> yamlPaths = new ArrayList<>();
+
+        PropertiesParser propertiesParser = new PropertiesParser();
+        List<Path> propertiesPaths = new ArrayList<>();
+
+        ProtoParser protoParser = new ProtoParser();
+        List<Path> protoPaths = new ArrayList<>();
+
+        HclParser hclParser = HclParser.builder().build();
+        List<Path> hclPaths = new ArrayList<>();
+
+        QuarkParser quarkParser = new QuarkParser();
+
+        resources.forEach(path -> {
+            if (jsonParser.accept(path)) {
+                jsonPaths.add(path);
+            } else if (xmlParser.accept(path)) {
+                xmlPaths.add(path);
+            } else if (yamlParser.accept(path)) {
+                yamlPaths.add(path);
+            } else if (propertiesParser.accept(path)) {
+                propertiesPaths.add(path);
+            } else if (protoParser.accept(path)) {
+                protoPaths.add(path);
+            } else if (hclParser.accept(path)) {
+                hclPaths.add(path);
+            } else if (quarkParser.accept(path)) {
                 quarkPaths.add(path);
-                return false;
             }
+        });
 
-            return true;
-        })) {
-            List<Path> resourceFiles = resources.collect(Collectors.toList());
-            List<S> sourceFiles = new ArrayList<>(resourceFiles.size());
+        sourceFiles.addAll((List<S>) jsonParser.parse(jsonPaths, baseDir, ctx));
+        alreadyParsed.addAll(jsonPaths);
 
-            JsonParser jsonParser = new JsonParser();
-            List<Path> jsonPaths = new ArrayList<>();
+        sourceFiles.addAll((List<S>) xmlParser.parse(xmlPaths, baseDir, ctx));
+        alreadyParsed.addAll(xmlPaths);
 
-            XmlParser xmlParser = new XmlParser();
-            List<Path> xmlPaths = new ArrayList<>();
+        sourceFiles.addAll((List<S>) yamlParser.parse(yamlPaths, baseDir, ctx));
+        alreadyParsed.addAll(yamlPaths);
 
-            YamlParser yamlParser = new YamlParser();
-            List<Path> yamlPaths = new ArrayList<>();
+        sourceFiles.addAll((List<S>) propertiesParser.parse(propertiesPaths, baseDir, ctx));
+        alreadyParsed.addAll(propertiesPaths);
 
-            PropertiesParser propertiesParser = new PropertiesParser();
-            List<Path> propertiesPaths = new ArrayList<>();
+        sourceFiles.addAll((List<S>) protoParser.parse(protoPaths, baseDir, ctx));
+        alreadyParsed.addAll(protoPaths);
 
-            ProtoParser protoParser = new ProtoParser();
-            List<Path> protoPaths = new ArrayList<>();
+        sourceFiles.addAll((List<S>) hclParser.parse(hclPaths, baseDir, ctx));
+        alreadyParsed.addAll(hclPaths);
 
-            HclParser hclParser = HclParser.builder().build();
-            List<Path> hclPaths = new ArrayList<>();
+        sourceFiles.addAll((List<S>) quarkParser.parse(quarkPaths, baseDir, ctx));
+        alreadyParsed.addAll(quarkPaths);
 
-            QuarkParser quarkParser = new QuarkParser();
+        return sourceFiles;
+    }
 
-            resourceFiles.forEach(path -> {
-                if (jsonParser.accept(path)) {
-                    jsonPaths.add(path);
-                } else if (xmlParser.accept(path)) {
-                    xmlPaths.add(path);
-                } else if (yamlParser.accept(path)) {
-                    yamlPaths.add(path);
-                } else if (propertiesParser.accept(path)) {
-                    propertiesPaths.add(path);
-                } else if (protoParser.accept(path)) {
-                    protoPaths.add(path);
-                } else if (hclParser.accept(path)) {
-                    hclPaths.add(path);
-                } else if (quarkParser.accept(path)) {
-                    quarkPaths.add(path);
-                }
-            });
+    private boolean isOverSizeThreshold(long fileSize) {
+        return (sizeThresholdMb > 0 && fileSize > sizeThresholdMb * 1024L * 1024L);
+    }
 
-            sourceFiles.addAll((List<S>) jsonParser.parse(jsonPaths, baseDir, ctx));
-            alreadyParsed.addAll(jsonPaths);
-
-            sourceFiles.addAll((List<S>) xmlParser.parse(xmlPaths, baseDir, ctx));
-            alreadyParsed.addAll(xmlPaths);
-
-            sourceFiles.addAll((List<S>) yamlParser.parse(yamlPaths, baseDir, ctx));
-            alreadyParsed.addAll(yamlPaths);
-
-            sourceFiles.addAll((List<S>) propertiesParser.parse(propertiesPaths, baseDir, ctx));
-            alreadyParsed.addAll(propertiesPaths);
-
-            sourceFiles.addAll((List<S>) protoParser.parse(protoPaths, baseDir, ctx));
-            alreadyParsed.addAll(protoPaths);
-
-            sourceFiles.addAll((List<S>) hclParser.parse(hclPaths, baseDir, ctx));
-            alreadyParsed.addAll(hclPaths);
-
-            sourceFiles.addAll((List<S>) quarkParser.parse(quarkPaths, baseDir, ctx));
-            alreadyParsed.addAll(quarkPaths);
-
-            return sourceFiles;
-        } catch (IOException e) {
-            logger.error(e.getMessage(), e);
-            throw new UncheckedIOException(e);
+    private boolean isIgnored(Path baseDir) {
+        for (PathMatcher ignored : exclusions) {
+            if (ignored.matches(baseDir)) {
+                return true;
+            }
         }
+        return false;
     }
 }

--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -1,7 +1,6 @@
 package org.openrewrite.maven;
 
 import org.apache.maven.plugin.logging.Log;
-import org.checkerframework.checker.units.qual.A;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Parser;

--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -54,6 +54,7 @@ public class ResourceParser {
             Collection<Path> alreadyParsed,
             ExecutionContext ctx) {
 
+        List<Path> quarkPaths = new ArrayList<>();
         try (Stream<Path> resources = Files.find(searchDir, 16, (path, attrs) -> {
             // Prevent java files from being parsed as quarks.
             if (path.toString().endsWith(".java")) {
@@ -89,7 +90,8 @@ public class ResourceParser {
             if ((sizeThresholdMb > 0 && fileSize > sizeThresholdMb * 1024L * 1024L)) {
                 logger.info("Parsing as Quark " + path + " as its size + " + fileSize / (1024L * 1024L) +
                         "Mb exceeds size threshold " + sizeThresholdMb + "Mb");
-                return true;
+                quarkPaths.add(path);
+                return false;
             }
 
             return true;
@@ -116,7 +118,6 @@ public class ResourceParser {
             List<Path> hclPaths = new ArrayList<>();
 
             QuarkParser quarkParser = new QuarkParser();
-            List<Path> quarkPaths = new ArrayList<>();
 
             resourceFiles.forEach(path -> {
                 if (jsonParser.accept(path)) {


### PR DESCRIPTION
Changes:

- Files ignored due to threshold are parsed as a `Quark`.
- Added `QuarkParser` to `ResourceParser`.
- ResourceParser will only parse files in the current maven project.
- Replaced `Files.find` with `Files.walkFileTree`.

fixes #346