### PR TITLE
Collect maven poms with LinkedHashSet.

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -145,7 +145,7 @@ public class MavenMojoProjectParser {
             return null;
         }
 
-        Set<Path> allPoms = collectPoms(mavenProject, new HashSet<>());
+        Set<Path> allPoms = collectPoms(mavenProject, new LinkedHashSet<>());
         mavenSession.getProjectDependencyGraph().getUpstreamProjects(mavenProject, true).forEach(p -> collectPoms(p, allPoms));
         MavenParser.Builder mavenParserBuilder = MavenParser.builder().mavenConfig(baseDir.resolve(".mvn/maven.config"));
 


### PR DESCRIPTION
Changes:

- parseMaven will return a `Maven` `Xml.Document` that matches the current project.

fixes #351