### PR TITLE
Refactoring to the plugin to only parse and run on the last project. fixes #349

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
@@ -18,12 +18,14 @@ package org.openrewrite.maven;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.*;
 import org.openrewrite.Result;
+import org.openrewrite.internal.lang.Nullable;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.stream.Stream;
 
 /**
@@ -33,9 +35,9 @@ import java.util.stream.Stream;
  */
 public class AbstractRewriteDryRunMojo extends AbstractRewriteMojo {
 
-    @SuppressWarnings("NotNullFieldNotInitialized")
-    @Parameter(property = "reportOutputDirectory", defaultValue = "${project.reporting.outputDirectory}/rewrite")
-    private File reportOutputDirectory;
+    @Parameter(property = "reportOutputDirectory")
+    @Nullable
+    private String reportOutputDirectory;
 
     /**
      * Whether to throw an exception if there are any result changes produced.
@@ -46,6 +48,12 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteMojo {
     @Override
     public void execute() throws MojoExecutionException {
         MavenOptsHelper.checkAndLogMissingJvmModuleExports(getLog());
+
+        //Defer execution of rewrite's parsing and recipe execution until the last project.
+        if (!project.getId().equals(mavenSession.getProjects().get(mavenSession.getProjects().size() - 1).getId())) {
+            return;
+        }
+
         ResultsContainer results = listResults();
 
         if (results.isNotEmpty()) {
@@ -79,10 +87,19 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteMojo {
                 logRecipesThatMadeChanges(result);
             }
 
-            //noinspection ResultOfMethodCallIgnored
-            reportOutputDirectory.mkdirs();
+            Path outPath;
+            if (reportOutputDirectory != null) {
+                outPath = Paths.get(reportOutputDirectory);
+            } else {
+                outPath = Paths.get(mavenSession.getTopLevelProject().getBuild().getDirectory()).resolve("rewrite");
+            }
+            try {
+                Files.createDirectories(outPath);
+            } catch (IOException e) {
+                throw new RuntimeException("Could not create the folder [ " + outPath + "].", e);
+            }
 
-            Path patchFile = reportOutputDirectory.toPath().resolve("rewrite.patch");
+            Path patchFile = outPath.resolve("rewrite.patch");
             try (BufferedWriter writer = Files.newBufferedWriter(patchFile)) {
                 Stream.concat(
                                 Stream.concat(results.generated.stream(), results.deleted.stream()),

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -172,8 +172,13 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
                 }
             }
             ExecutionContext ctx = executionContext();
-            MavenMojoProjectParser projectParser = new MavenMojoProjectParser(getLog(), baseDir, pomCacheEnabled, pomCacheDirectory, project, runtime, skipMavenParsing, getExclusions(), sizeThresholdMb, mavenSession, settingsDecrypter);
-            List<SourceFile> sourceFiles = projectParser.listSourceFiles(styles, ctx);
+
+            //Parse and collect source files from each project in the maven session.
+            MavenMojoProjectParser projectParser = new MavenMojoProjectParser(getLog(), baseDir, pomCacheEnabled, pomCacheDirectory, runtime, skipMavenParsing, getExclusions(), sizeThresholdMb, mavenSession, settingsDecrypter);
+            List<SourceFile> sourceFiles = new ArrayList<>();
+            for (MavenProject project : mavenSession.getProjects()) {
+                sourceFiles.addAll(projectParser.listSourceFiles(project, styles, ctx));
+            }
 
             getLog().info("Running recipe(s)...");
             List<Result> results = recipe.run(sourceFiles, ctx).stream()

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
@@ -34,6 +34,12 @@ public class AbstractRewriteRunMojo extends AbstractRewriteMojo {
     @Override
     public void execute() throws MojoExecutionException {
         MavenOptsHelper.checkAndLogMissingJvmModuleExports(getLog());
+
+        //Defer execution of rewrite's parsing and recipe execution until the last project.
+        if (!project.getId().equals(mavenSession.getProjects().get(mavenSession.getProjects().size() - 1).getId())) {
+            return;
+        }
+
         ResultsContainer results = listResults();
 
         if (results.isNotEmpty()) {

--- a/src/main/java/org/openrewrite/maven/CycloneDxBomMojo.java
+++ b/src/main/java/org/openrewrite/maven/CycloneDxBomMojo.java
@@ -14,6 +14,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 
 /**
  * Generate a CycloneDx bill of materials outlining the project's dependencies, including transitive dependencies.
@@ -31,7 +32,7 @@ public class CycloneDxBomMojo extends AbstractRewriteMojo {
     public void execute() throws MojoExecutionException {
         ExecutionContext ctx = executionContext();
         Path baseDir = getBaseDir();
-        Xml.Document maven = new MavenMojoProjectParser(getLog(), baseDir, pomCacheEnabled, pomCacheDirectory, project, runtime, skipMavenParsing, getExclusions(), sizeThresholdMb, mavenSession, settingsDecrypter).parseMaven(ctx);
+        Xml.Document maven = new MavenMojoProjectParser(getLog(), baseDir, pomCacheEnabled, pomCacheDirectory, runtime, skipMavenParsing, getExclusions(), sizeThresholdMb, mavenSession, settingsDecrypter).parseMaven(project, Collections.emptyList(), ctx);
         if (maven != null) {
             File cycloneDxBom = buildCycloneDxBom(maven);
             projectHelper.attachArtifact(project, "xml", "cyclonedx", cycloneDxBom);

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -18,6 +18,7 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.internal.JavaTypeCache;
 import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.java.style.Autodetect;
@@ -70,6 +71,8 @@ public class MavenMojoProjectParser {
 
     @Nullable
     static MavenPomCache pomCache;
+
+    static JavaTypeCache typeCache = new JavaTypeCache();
 
     private final Log logger;
     private final Path baseDir;
@@ -132,6 +135,7 @@ public class MavenMojoProjectParser {
 
         JavaParser javaParser = JavaParser.fromJavaVersion()
                 .styles(styles)
+                .typeCache(typeCache)
                 .logCompilationWarningsAndErrors(false)
                 .build();
 

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -165,16 +165,16 @@ public class MavenMojoProjectParser {
         // java source.
         List<J.CompilationUnit> parsedJava = ListUtils.map(maybeAutodetectStyles(javaParser.parse(mainJavaSources, baseDir, ctx), styles),
                 addProvenance(baseDir, projectProvenance, generatedSourcePaths));
-        logger.info(projectLogPrefix + "Parsed " + parsedJava.size() + " java source files in main scope.");
+        logger.debug(projectLogPrefix + "Parsed " + parsedJava.size() + " java source files in main scope.");
         sourceFiles.addAll(parsedJava);
 
-        ResourceParser rp = new ResourceParser(baseDir, projectLogPrefix, logger, exclusions, sizeThresholdMb, pathsToOtherMavenProjects());
+        ResourceParser rp = new ResourceParser(baseDir, logger, exclusions, sizeThresholdMb, pathsToOtherMavenProjects());
 
         List<SourceFile> parsedResourceFiles = ListUtils.map(
                 rp.parse(mavenProject.getBasedir().toPath().resolve("src/main/resources"), alreadyParsed),
                 addProvenance(baseDir, ListUtils.concat(projectProvenance, javaParser.getSourceSet(ctx)), null));
 
-        logger.info(projectLogPrefix + "Parsed " + parsedResourceFiles.size() + " resource files in main scope.");
+        logger.debug(projectLogPrefix + "Parsed " + parsedResourceFiles.size() + " resource files in main scope.");
         // Any resources parsed from "main/resources" should also have the main source set added to them.
         sourceFiles.addAll(parsedResourceFiles);
 
@@ -189,12 +189,13 @@ public class MavenMojoProjectParser {
         // JavaParser will add SourceSet Markers to any Java SourceFile, so only adding the project provenance info to
         // java source.
         List<Path> testJavaSources = listJavaSources(mavenProject.getBuild().getTestSourceDirectory());
+        alreadyParsed.addAll(testJavaSources);
 
         parsedJava = ListUtils.map(
                 maybeAutodetectStyles(javaParser.parse(testJavaSources, baseDir, ctx), styles),
                 addProvenance(baseDir, projectProvenance, null));
 
-        logger.info(projectLogPrefix + "Parsed " + parsedJava.size() + " java source files in test scope.");
+        logger.debug(projectLogPrefix + "Parsed " + parsedJava.size() + " java source files in test scope.");
         sourceFiles.addAll(parsedJava);
 
         // Any resources parsed from "test/resources" should also have the test source set added to them.
@@ -202,7 +203,7 @@ public class MavenMojoProjectParser {
                 rp.parse(mavenProject.getBasedir().toPath().resolve("src/test/resources"), alreadyParsed),
                 addProvenance(baseDir, ListUtils.concat(projectProvenance, javaParser.getSourceSet(ctx)), null)
         );
-        logger.info(projectLogPrefix + "Parsed " + parsedResourceFiles.size() + " resource files in main scope.");
+        logger.debug(projectLogPrefix + "Parsed " + parsedResourceFiles.size() + " resource files in test scope.");
         sourceFiles.addAll(parsedResourceFiles);
 
         //Collect any additional files that were not parsed above.
@@ -210,7 +211,7 @@ public class MavenMojoProjectParser {
                 rp.parse(mavenProject.getBasedir().toPath(), alreadyParsed),
                 addProvenance(baseDir, projectProvenance, null)
         );
-        logger.info(projectLogPrefix + "Parsed " + parsedResourceFiles.size() + " additional files found within the project.");
+        logger.debug(projectLogPrefix + "Parsed " + parsedResourceFiles.size() + " additional files found within the project.");
         sourceFiles.addAll(parsedResourceFiles);
 
         return sourceFiles;

--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -24,16 +24,14 @@ import java.util.stream.Collectors;
 public class ResourceParser {
     private static final Set<String> DEFAULT_IGNORED_DIRECTORIES = new HashSet<>(Arrays.asList("build", "target", "out", ".gradle", ".idea", ".project", "node_modules", ".git", ".metadata", ".DS_Store"));
 
-    private final String projectLogPrefix;
     private final Path baseDir;
     private final Log logger;
     private final Collection<PathMatcher> exclusions;
     private final int sizeThresholdMb;
     private final Collection<Path> excludedDirectories;
 
-    public ResourceParser(Path baseDir, String projectLogPrefix, Log logger, Collection<String> exclusions, int sizeThresholdMb, Collection<Path> excludedDirectories) {
+    public ResourceParser(Path baseDir, Log logger, Collection<String> exclusions, int sizeThresholdMb, Collection<Path> excludedDirectories) {
         this.baseDir = baseDir;
-        this.projectLogPrefix = projectLogPrefix;
         this.logger = logger;
         this.exclusions = exclusionMatchers(baseDir, exclusions);
         this.sizeThresholdMb = sizeThresholdMb;
@@ -51,13 +49,13 @@ public class ResourceParser {
         if (!searchDir.toFile().exists()) {
             return sourceFiles;
         }
-        Consumer<Throwable> errorConsumer = t -> logger.error(projectLogPrefix + "Error parsing", t);
+        Consumer<Throwable> errorConsumer = t -> logger.error("Error parsing", t);
         InMemoryExecutionContext ctx = new InMemoryExecutionContext(errorConsumer);
 
         try {
             sourceFiles.addAll(parseSourceFiles(searchDir, alreadyParsed, ctx));
         } catch (IOException e) {
-            logger.error(projectLogPrefix + e.getMessage(), e);
+            logger.error(e.getMessage(), e);
             throw new UncheckedIOException(e);
         }
 
@@ -86,7 +84,7 @@ public class ResourceParser {
                 if (attrs.size() != 0 && !attrs.isOther() && !attrs.isSymbolicLink() &&
                         !alreadyParsed.contains(file) && !isExcluded(file)) {
                     if (isOverSizeThreshold(attrs.size())) {
-                        logger.info(projectLogPrefix + "Parsing as quark " + file + " as its size + " + attrs.size() / (1024L * 1024L) +
+                        logger.info("Parsing as quark " + file + " as its size + " + attrs.size() / (1024L * 1024L) +
                                 "Mb exceeds size threshold " + sizeThresholdMb + "Mb");
                         quarkPaths.add(file);
                     } else {

--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -1,6 +1,7 @@
 package org.openrewrite.maven;
 
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.SourceFile;
@@ -23,14 +24,16 @@ import java.util.stream.Collectors;
 public class ResourceParser {
     private static final Set<String> DEFAULT_IGNORED_DIRECTORIES = new HashSet<>(Arrays.asList("build", "target", "out", ".gradle", ".idea", ".project", "node_modules", ".git", ".metadata", ".DS_Store"));
 
+    private final String projectLogPrefix;
     private final Path baseDir;
     private final Log logger;
     private final Collection<PathMatcher> exclusions;
     private final int sizeThresholdMb;
     private final Collection<Path> excludedDirectories;
 
-    public ResourceParser(Path baseDir, Log logger, Collection<String> exclusions, int sizeThresholdMb, Collection<Path> excludedDirectories) {
+    public ResourceParser(Path baseDir, String projectLogPrefix, Log logger, Collection<String> exclusions, int sizeThresholdMb, Collection<Path> excludedDirectories) {
         this.baseDir = baseDir;
+        this.projectLogPrefix = projectLogPrefix;
         this.logger = logger;
         this.exclusions = exclusionMatchers(baseDir, exclusions);
         this.sizeThresholdMb = sizeThresholdMb;
@@ -48,13 +51,13 @@ public class ResourceParser {
         if (!searchDir.toFile().exists()) {
             return sourceFiles;
         }
-        Consumer<Throwable> errorConsumer = t -> logger.error("Error parsing", t);
+        Consumer<Throwable> errorConsumer = t -> logger.error(projectLogPrefix + "Error parsing", t);
         InMemoryExecutionContext ctx = new InMemoryExecutionContext(errorConsumer);
 
         try {
             sourceFiles.addAll(parseSourceFiles(searchDir, alreadyParsed, ctx));
         } catch (IOException e) {
-            logger.error(e.getMessage(), e);
+            logger.error(projectLogPrefix + e.getMessage(), e);
             throw new UncheckedIOException(e);
         }
 
@@ -83,7 +86,7 @@ public class ResourceParser {
                 if (attrs.size() != 0 && !attrs.isOther() && !attrs.isSymbolicLink() &&
                         !alreadyParsed.contains(file) && !isExcluded(file)) {
                     if (isOverSizeThreshold(attrs.size())) {
-                        logger.info("Parsing as quark " + file + " as its size + " + attrs.size() / (1024L * 1024L) +
+                        logger.info(projectLogPrefix + "Parsing as quark " + file + " as its size + " + attrs.size() / (1024L * 1024L) +
                                 "Mb exceeds size threshold " + sizeThresholdMb + "Mb");
                         quarkPaths.add(file);
                     } else {


### PR DESCRIPTION
Reworked the maven plugin to run on the last project in the maven session. The plugin will then iterate through all of the projects in the maven session (in reactor order) to parse source files and will then run the recipe across all source files (in all projects).