### PR TITLE
Auto-detect style if the list of styles is empty in MavenMojoProjectParser.

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -474,7 +474,7 @@ public class MavenMojoProjectParser {
     }
 
     private List<J.CompilationUnit> maybeAutodetectStyles(List<J.CompilationUnit> sourceFiles, @Nullable Iterable<NamedStyles> styles) {
-        if (styles != null) {
+        if (styles != null && styles.spliterator().getExactSizeIfKnown() > 0) {
             return sourceFiles;
         }
         Autodetect autodetect = Autodetect.detect(sourceFiles);


### PR DESCRIPTION
Changes:

- Styles in maven projects will be auto-detected when a style is not provided.

fixes #378