### PR TITLE
Upping maven-filter from 3.2.0 (Aug 2020) to 3.3.0 (Jun, 2022)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,8 +170,9 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-filtering</artifactId>
-            <version>3.2.0</version>
+            <version>3.3.0</version>
         </dependency>
+
         <dependency>
             <!-- plugin interfaces and base classes -->
             <groupId>org.apache.maven</groupId>

--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -5,6 +5,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @SuppressWarnings("FieldMayBeFinal")
 public abstract class ConfigurableRewriteMojo extends AbstractMojo {
@@ -110,7 +111,12 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
                 if (computedRecipes == null) {
                     Set<String> res = toLinkedHashSet(rewriteActiveRecipes);
                     if (res.isEmpty()) {
-                        res.addAll(activeRecipes);
+                        res.addAll(
+                            activeRecipes
+                                .stream()
+                                .filter(Objects::nonNull)
+                                .collect(Collectors.toList())
+                        );
                     }
                     computedRecipes = Collections.unmodifiableSet(res);
                 }

--- a/src/test/java/org/openrewrite/maven/ConfigureMojoITNoActiveRecipe.java
+++ b/src/test/java/org/openrewrite/maven/ConfigureMojoITNoActiveRecipe.java
@@ -1,0 +1,30 @@
+package org.openrewrite.maven;
+
+import com.soebes.itf.jupiter.extension.MavenCLIOptions;
+import com.soebes.itf.jupiter.extension.MavenGoal;
+import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
+import com.soebes.itf.jupiter.extension.MavenOption;
+import com.soebes.itf.jupiter.extension.MavenTest;
+import com.soebes.itf.jupiter.extension.SystemProperties;
+import com.soebes.itf.jupiter.extension.SystemProperty;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+
+import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
+
+@MavenJupiterExtension
+@MavenOption(MavenCLIOptions.NO_TRANSFER_PROGRESS)
+@MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:discover")
+@SuppressWarnings("NewClassNamingConvention")
+public class ConfigureMojoITNoActiveRecipe {
+
+    @MavenTest
+    void single_project(MavenExecutionResult result) {
+        assertThat(result)
+                .isSuccessful()
+                .out()
+                .error()
+                .noneSatisfy(line -> {
+                    assertThat(line).contains("Could not find recipe 'null' among available recipes");
+                });
+    }
+}

--- a/src/test/resources-its/org/openrewrite/maven/ConfigureMojoITNoActiveRecipe/single_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/ConfigureMojoITNoActiveRecipe/single_project/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>single_project</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>ConfigureMojoITNoActiveRecipe#single_project</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>${some.property}</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Fixing a null value in the activeRecipes collection causing the discover goal to fail even if no recipes should be run. This can happen when having a property as the value of the recipe name and that property is null. Then the collection will only contain a single element which is null