### PR TITLE
Improve 'discover' goal behaviour for multi-module/no projects

### DIFF
--- a/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
@@ -21,7 +21,7 @@ import java.util.HashSet;
  * {@code ./mvnw rewrite:discover -Ddetail=true -Drecipe=<recipe-name>} to display recipe configuration details. For example:<br>
  * {@code ./mvnw rewrite:discover -Ddetail=true -Drecipe=org.openrewrite.java.format.AutoFormat}
  */
-@Mojo(name = "discover", threadSafe = true)
+@Mojo(name = "discover", threadSafe = true, requiresProject = false, aggregator = true)
 @SuppressWarnings("unused")
 public class RewriteDiscoverMojo extends AbstractRewriteMojo {
 

--- a/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
@@ -78,4 +78,16 @@ public class RewriteDiscoverIT {
         assertThat(result).out().warn().isEmpty();
     }
 
+    @MavenTest
+    void rewrite_discover_multi_module(MavenExecutionResult result) {
+        assertThat(result)
+            .isSuccessful()
+            .out()
+            .info()
+            .anySatisfy(line -> assertThat(line).matches("^a.*SKIPPED$"))
+            .anySatisfy(line -> assertThat(line).matches("^b.*SKIPPED$"));
+
+        assertThat(result).out().warn().isEmpty();
+    }
+
 }

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_multi_module/a/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_multi_module/a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.openrewrite.maven</groupId>
+        <artifactId>rewrite_discover_multi_module</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>a</artifactId>
+
+</project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_multi_module/b/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_multi_module/b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.openrewrite.maven</groupId>
+        <artifactId>rewrite_discover_multi_module</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>b</artifactId>
+
+</project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_multi_module/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_multi_module/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>rewrite_discover_multi_module</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+    <name>RewriteDiscoverIT#multi_module</name>
+
+    <modules>
+        <module>a</module>
+        <module>b</module>
+    </modules>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <pomCacheDirectory>
+                        ${project.build.directory}/maven-it/org/openrewrite/maven/RewriteDiscoverIT/rewrite_discover_multi_module/project/target/pomCache
+                    </pomCacheDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Allows for the execution of the `discover` goal from non-Maven projects.
Will only execute the `discover` goal once per project reactor rather than once for each module.

Fixes https://github.com/openrewrite/rewrite-maven-plugin/issues/386.