### PR TITLE
Improve documentation for the 'bootstrap' profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If you're looking for more information on the output from a test, try checking t
 
 ### Using this plugin against itself
 
-The `pom.xml` has the a `profile` for using the `rewrite-maven-plugin` applied to itself (it's a helpful plugin, why not use it to help develop itself?). This needs to be in it's own profile to prevent errors during deployment.
+The `pom.xml` file contains a `bootstrap` profile to use the `rewrite-maven-plugin` against itself (it's a helpful plugin, why not use it to help develop itself?).
 
 ```sh
 ./mvnw -Pbootstrap rewrite:dryRun


### PR DESCRIPTION
Documentation for the `bootstrap` profile within the [README.md](https://github.com/openrewrite/rewrite-maven-plugin/compare/main...dsibilio:fix/grammar-check?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) file looks broken as-is.

This PR just tries to simplify the docs and make the relevant sentence more understandable.