### PR TITLE
Pinned com.puppycrawl.tools:checkstyle back to 9.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore(ci)"
+    ignore:
+      - dependency-name: "com.puppycrawl.tools:checkstyle"

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,8 @@
         <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.1</version>
+            <!--suppress MavenPackageUpdate Pinned to 9.3, because 10.x does not support Java 8. -->
+            <version>9.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>


### PR DESCRIPTION
Changes:

- Plugin is compatible with Java 8.
- Added the `checkstyle` dependency as ignored in `dependabot.yaml`.

fixes #393