### PR TITLE
Configure a set of file masks to be included in plain text parsing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </scm>
 
     <properties>
-        <rewrite.version>7.27.3</rewrite.version>
+        <rewrite.version>7.28.0-SNAPSHOT</rewrite.version>
 
         <!-- using 'ssh' url scheme by default, which assumes a human is performing git operations leveraging an ssh key -->
         <developerConnectionUrl>scm:git:ssh://git@github.com/openrewrite/rewrite-maven-plugin.git
@@ -499,7 +499,7 @@
                     <plugin>
                         <groupId>org.openrewrite.maven</groupId>
                         <artifactId>rewrite-maven-plugin</artifactId>
-                        <version>4.22.2</version>
+                        <version>4.31.3</version>
                         <configuration>
                             <activeRecipes>
                                 <recipe>org.openrewrite.java.format.AutoFormat</recipe>

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -197,7 +197,7 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
             ExecutionContext ctx = executionContext();
 
             //Parse and collect source files from each project in the maven session.
-            MavenMojoProjectParser projectParser = new MavenMojoProjectParser(getLog(), baseDir, pomCacheEnabled, pomCacheDirectory, runtime, skipMavenParsing, getExclusions(), sizeThresholdMb, mavenSession, settingsDecrypter);
+            MavenMojoProjectParser projectParser = new MavenMojoProjectParser(getLog(), baseDir, pomCacheEnabled, pomCacheDirectory, runtime, skipMavenParsing, getExclusions(), getPlainTextMasks(), sizeThresholdMb, mavenSession, settingsDecrypter);
 
             List<SourceFile> sourceFiles = new ArrayList<>();
             if (runPerSubmodule) {

--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -76,6 +76,39 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
     }
 
     @Nullable
+    @Parameter(property = "plainTextMasks")
+    private Set<String> plainTextMasks = null;
+
+    @Nullable
+    @Parameter(property = "rewrite.plainTextMasks")
+    private String rewritePlainTextMasks = null;
+
+    protected Set<String> getPlainTextMasks() {
+        if (plainTextMasks == null && rewritePlainTextMasks == null) {
+            //If not defined, use a default set of masks
+            return new HashSet<>(Arrays.asList(
+                    "**/META-INF/services/**",
+                    "**/.gitignore",
+                    "**/.gitattributes",
+                    "**/.java-version",
+                    "**/.sdkmanrc",
+                    "**/*.sh",
+                    "**/*.bash",
+                    "**/*.bat",
+                    "**/*.ksh",
+                    "**/*.txt",
+                    "**/*.jsp"
+            ));
+        } else {
+            Set<String> masks = toSet(rewritePlainTextMasks);
+            if (plainTextMasks != null) {
+                masks.addAll(plainTextMasks);
+            }
+            return masks;
+        }
+    }
+
+    @Nullable
     @Parameter(property = "sizeThresholdMb", defaultValue = "10")
     protected int sizeThresholdMb;
 

--- a/src/main/java/org/openrewrite/maven/CycloneDxBomMojo.java
+++ b/src/main/java/org/openrewrite/maven/CycloneDxBomMojo.java
@@ -32,7 +32,7 @@ public class CycloneDxBomMojo extends AbstractRewriteMojo {
     public void execute() throws MojoExecutionException {
         ExecutionContext ctx = executionContext();
         Path baseDir = getBaseDir();
-        Xml.Document maven = new MavenMojoProjectParser(getLog(), baseDir, pomCacheEnabled, pomCacheDirectory, runtime, skipMavenParsing, getExclusions(), sizeThresholdMb, mavenSession, settingsDecrypter).parseMaven(project, Collections.emptyList(), ctx);
+        Xml.Document maven = new MavenMojoProjectParser(getLog(), baseDir, pomCacheEnabled, pomCacheDirectory, runtime, skipMavenParsing, getExclusions(), getPlainTextMasks(), sizeThresholdMb, mavenSession, settingsDecrypter).parseMaven(project, Collections.emptyList(), ctx);
         if (maven != null) {
             File cycloneDxBom = buildCycloneDxBom(maven);
             projectHelper.attachArtifact(project, "xml", "cyclonedx", cycloneDxBom);

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -85,12 +85,13 @@ public class MavenMojoProjectParser {
     private final BuildTool buildTool;
 
     private final Collection<String> exclusions;
+    private final Collection<String> plainTextMasks;
     private final int sizeThresholdMb;
     private final MavenSession mavenSession;
     private final SettingsDecrypter settingsDecrypter;
 
     @SuppressWarnings("BooleanParameter")
-    public MavenMojoProjectParser(Log logger, Path baseDir, boolean pomCacheEnabled, @Nullable String pomCacheDirectory, RuntimeInformation runtime, boolean skipMavenParsing, Collection<String> exclusions, int sizeThresholdMb, MavenSession session, SettingsDecrypter settingsDecrypter) {
+    public MavenMojoProjectParser(Log logger, Path baseDir, boolean pomCacheEnabled, @Nullable String pomCacheDirectory, RuntimeInformation runtime, boolean skipMavenParsing, Collection<String> exclusions, Collection<String> plainTextMasks, int sizeThresholdMb, MavenSession session, SettingsDecrypter settingsDecrypter) {
         this.logger = logger;
         this.baseDir = baseDir;
         this.pomCacheEnabled = pomCacheEnabled;
@@ -98,6 +99,7 @@ public class MavenMojoProjectParser {
         this.skipMavenParsing = skipMavenParsing;
         this.buildTool = new BuildTool(randomId(), BuildTool.Type.Maven, runtime.getMavenVersion());
         this.exclusions = exclusions;
+        this.plainTextMasks = plainTextMasks;
         this.sizeThresholdMb = sizeThresholdMb;
         this.mavenSession = session;
         this.settingsDecrypter = settingsDecrypter;
@@ -123,7 +125,7 @@ public class MavenMojoProjectParser {
                 .typeCache(typeCache)
                 .logCompilationWarningsAndErrors(false)
                 .build();
-        ResourceParser rp = new ResourceParser(baseDir, logger, exclusions, sizeThresholdMb, pathsToOtherMavenProjects(mavenProject));
+        ResourceParser rp = new ResourceParser(baseDir, logger, exclusions, plainTextMasks, sizeThresholdMb, pathsToOtherMavenProjects(mavenProject));
 
         sourceFiles.addAll(processMainSources(mavenProject, javaParser, rp, projectProvenance, alreadyParsed, styles, ctx));
         sourceFiles.addAll(processTestSources(mavenProject, javaParser, rp, projectProvenance, alreadyParsed, styles, ctx));


### PR DESCRIPTION
Add the ability to configure which files will be parsed as plain text. If no configuration is applied the defaults for the plugin are: 

```
**/META-INF/services/**
**/.gitignore
**/.gitattributes
**/.java-version
**/.sdkmanrc
**/*.sh
**/*.bash
**/*.bat
**/*.ksh
**/*.txt
**/*.jsp
```

This is related to https://github.com/openrewrite/rewrite/issues/2134