### PR TITLE
Fixed Dockerfile in default plainTextMasks

### DIFF
--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -104,7 +104,7 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
                     "**/*.txt",
                     "**/*.jsp",
                     "**/*.sql",
-                    "Dockerfile"
+                    "**/Dockerfile"
             ));
         } else {
             Set<String> masks = toSet(rewritePlainTextMasks);


### PR DESCRIPTION
this wasn't actually matching a Dockerfile in the project root dir; now it does