### PR TITLE
Fix Jackson/Netty CVE issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,8 @@
         <java.version>1.8</java.version>
 
         <!-- dependencies and plugins -->
+        <jackson-bom.version>2.13.4.20221013</jackson-bom.version>
+        <netty.version>4.1.86.Final</netty.version>
         <rocksdbjni.version>7.7.3</rocksdbjni.version>
         <itf-maven.version>0.11.0</itf-maven.version>
         <junit-jupiter.version>5.9.1</junit-jupiter.version>
@@ -80,6 +82,24 @@
         <maven-release-plugin.version>3.0.0-M7</maven-release-plugin.version>
         <maven-plugin-tools.version>3.7.0</maven-plugin-tools.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -147,7 +167,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
-            <version>2.13.4</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer.prometheus</groupId>


### PR DESCRIPTION
Address CVEs by importing jackson and netty boms and pining those boms to versions that address CVEs.

https://github.com/moderneinc/dependency-vulnerability-reports/issues/467