### PR TITLE
fix stream closed error when using a URL in the config

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -82,9 +82,7 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
             URI uri = new URI(configLocation);
             if(uri.getScheme() != null && uri.getScheme().startsWith("http")) {
                 HttpSender httpSender = new HttpUrlConnectionSender();
-                try(HttpSender.Response response = httpSender.get(configLocation).send()) {
-                    return new Config(response.getBody(), uri);
-                }
+                return new Config(httpSender.get(configLocation).send().getBody(), uri);
             }
         } catch (URISyntaxException e) {
             // Try to load as a path

--- a/src/test/java/org/openrewrite/maven/AbstractRewriteMojoTest.java
+++ b/src/test/java/org/openrewrite/maven/AbstractRewriteMojoTest.java
@@ -18,7 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AbstractRewriteMojoTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"rewrite.yml", "https://httpstat.us/200"})
+    @ValueSource(strings = {
+        "rewrite.yml",
+        "https://httpstat.us/200",
+        "https://raw.githubusercontent.com/quarkusio/quarkus/main/jakarta/quarkus3.yml"
+    })
     void configLocation(String loc, @TempDir Path temp) throws IOException {
         AbstractRewriteMojo mojo = new AbstractRewriteMojo() {
             {


### PR DESCRIPTION
Fix issue https://github.com/openrewrite/rewrite-maven-plugin/issues/483.
### root cause
The "try-with-resources" block closed the response automatically, so at the consuming place of the `config.inputStream`, when reading from the stream, it has been closed.
