### PR TITLE
fix - BOM Usage instead of separate dependencies with properties. (#504)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
         <netty.version>4.1.87.Final</netty.version>
         <rocksdbjni.version>7.8.3</rocksdbjni.version>
         <itf-maven.version>0.12.0</itf-maven.version>
-        <junit-jupiter.version>5.9.2</junit-jupiter.version>
         <maven-dependencies.version>3.9.0</maven-dependencies.version>
         <maven-release-plugin.version>3.0.0-M7</maven-release-plugin.version>
         <maven-plugin-tools.version>3.7.1</maven-plugin-tools.version>
@@ -97,6 +96,20 @@
                 <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.9.2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-bom</artifactId>
+                <version>3.24.2</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -257,19 +270,16 @@
 
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -283,7 +293,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
 - remove junit-jupiter.version property because we have only a single location.