### PR TITLE
feat: Add rewrite.skip to skip execution

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
@@ -18,7 +18,6 @@ package org.openrewrite.maven;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.openrewrite.Result;
-import org.openrewrite.internal.RecipeRunException;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.io.BufferedWriter;
@@ -47,6 +46,10 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if (rewriteSkip) {
+            getLog().info("Skipping execution");
+            return;
+        }
 
         //If the plugin is configured to run over all projects (at the end of the build) only proceed if the plugin
         //is being run on the last project.

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
@@ -38,6 +38,10 @@ public class AbstractRewriteRunMojo extends AbstractRewriteMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if (rewriteSkip) {
+            getLog().info("Skipping execution");
+            return;
+        }
 
         //If the plugin is configured to run over all projects (at the end of the build) only proceed if the plugin
         //is being run on the last project.

--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -47,6 +47,9 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
     @Parameter(property = "rewrite.pomCacheDirectory", alias = "pomCacheDirectory")
     protected String pomCacheDirectory;
 
+    @Parameter(property = "rewrite.skip", defaultValue = "false")
+    protected boolean rewriteSkip;
+
     /**
      * When enabled, skip parsing Maven `pom.xml`s, and any transitive poms, as source files.
      * This can be an efficiency improvement in certain situations.


### PR DESCRIPTION
Just a simple way to skip plugin execution by property to allow more granular control in the lifecycle without profiles.