### PR TITLE
Managing version of Kotlin at 1.8.10, to override the version (1.5.30…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <maven-dependencies.version>3.9.0</maven-dependencies.version>
         <maven-release-plugin.version>3.0.0-M7</maven-release-plugin.version>
         <maven-plugin-tools.version>3.7.1</maven-plugin-tools.version>
+        <kotlin.version>1.8.10</kotlin.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -108,6 +109,13 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-bom</artifactId>
                 <version>3.24.2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
…) which `jackson-module-kotlin` was applying

https://github.com/openrewrite/rewrite/issues/1722