### PR TITLE
Bump rewrite version to 8.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 
     <properties>
         <!-- Pinned versions, as RELEASE would make it into the published pom.xml -->
-        <rewrite.version>7.41.0-SNAPSHOT</rewrite.version>
+        <rewrite.version>8.0.0</rewrite.version>
         <rewrite.python.version>0.5.0-SNAPSHOT</rewrite.python.version>
 
         <!-- using 'ssh' url scheme by default, which assumes a human is performing git operations leveraging an ssh key -->

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -335,7 +335,6 @@ public class MavenMojoProjectParser {
     }
 
     public Map<MavenProject, Xml.Document> parseMaven(List<MavenProject> mavenProjects, Map<MavenProject, List<Marker>> projectProvenances, ExecutionContext ctx) {
-        // J.clearCaches();
         if (skipMavenParsing) {
             logger.info("Skipping Maven parsing...");
             return emptyMap();

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -335,7 +335,7 @@ public class MavenMojoProjectParser {
     }
 
     public Map<MavenProject, Xml.Document> parseMaven(List<MavenProject> mavenProjects, Map<MavenProject, List<Marker>> projectProvenances, ExecutionContext ctx) {
-        J.clearCaches();
+        // J.clearCaches();
         if (skipMavenParsing) {
             logger.info("Skipping Maven parsing...");
             return emptyMap();


### PR DESCRIPTION
Created this PR because unsure about `J.clearCaches();` which has been removed in rewrite8.