### PR TITLE
Adopt next -SNAPSHOT versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,5 +49,4 @@ jobs:
       - name: bump-rewrite-properties-to-snapshots
         run: |
           ./mvnw versions:update-properties -DincludeProperties=rewrite.version,rewrite.python.version -DallowSnapshots=true
-          git diff-index --quiet HEAD pom.xml || git commit -m "Bump rewrite.version properties" pom.xml && rm -f pom.xml.versionsBackup
-          git push origin main
+          git diff-index --quiet HEAD pom.xml || git commit -m "Bump rewrite.version properties" pom.xml && git push origin main && rm -f pom.xml.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
 
     <properties>
         <!-- Pinned versions, as RELEASE would make it into the published pom.xml -->
-        <rewrite.version>8.0.0</rewrite.version>
-        <rewrite.python.version>1.0.0</rewrite.python.version>
+        <rewrite.version>8.1.0-SNAPSHOT</rewrite.version>
+        <rewrite.python.version>1.1.0-SNAPSHOT</rewrite.python.version>
 
         <!-- using 'ssh' url scheme by default, which assumes a human is performing git operations leveraging an ssh key -->
         <developerConnectionUrl>scm:git:ssh://git@github.com/openrewrite/rewrite-maven-plugin.git


### PR DESCRIPTION
## What's changed?
- Git push only when there are changes
- Bump openrewrite version properties to next -SNAPSHOTs

## What's your motivation?
For consistency, and to prepare for the next release.

## Anything in particular you'd like reviewers to focus on?
Not sure if the next SNAPSHOTs are already available; CI will tell.

## Any additional context
https://github.com/moderneinc/moderne-maven-plugin/pull/157
