### PR TITLE
support rewrite.inactiveRecipes

### DIFF
--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -21,6 +21,13 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
     @Parameter(property = "rewrite.activeRecipes")
     protected String rewriteActiveRecipes;
 
+    @Parameter(property = "inactiveRecipes")
+    protected List<String> inactiveRecipes = Collections.emptyList();
+
+    @Nullable
+    @Parameter(property = "rewrite.inactiveRecipes")
+    protected String rewriteInactiveRecipes;
+
     @Parameter(property = "activeStyles")
     protected Set<String> activeStyles = Collections.emptySet();
 
@@ -143,6 +150,9 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
     private volatile Set<String> computedRecipes;
 
     @Nullable
+    private volatile Set<String> computedInactiveRecipes;
+
+    @Nullable
     private volatile Set<String> computedStyles;
 
     @Nullable
@@ -167,6 +177,27 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
         }
 
         return computedRecipes;
+    }
+
+    protected Set<String> getInactiveRecipes() {
+        if (computedInactiveRecipes == null) {
+            synchronized (this) {
+                if (computedInactiveRecipes == null) {
+                    Set<String> res = toLinkedHashSet(rewriteInactiveRecipes);
+                    if (res.isEmpty()) {
+                        res.addAll(
+                                inactiveRecipes
+                                        .stream()
+                                        .filter(Objects::nonNull)
+                                        .collect(Collectors.toList())
+                        );
+                    }
+                    computedInactiveRecipes = Collections.unmodifiableSet(res);
+                }
+            }
+        }
+
+        return computedInactiveRecipes;
     }
 
     protected Set<String> getActiveStyles() {


### PR DESCRIPTION
## What's changed?

support rewrite.inactiveRecipes

## What's your motivation?

when i use  a recipe (it consist of many recipe), maybe i want disable some leaf-recipe.

## Anything in particular you'd like reviewers to focus on?
please focus on is this idea is right? 

## Anyone you would like to review specifically?
<!-- @mention them here -->
anyone
## Have you considered any alternatives or workarounds?

> Recipe class add property `enable`. when `enable` is false this Recipe not work. 
>  
> `rewrite-maven-plugin` set param `rewrite.inactiveRecipes ` .
> 
> `rewrite-maven-plugin` find those recipes to recipe.setEnable(false)

is this idea better? but implement code difficult

## Any additional context
none
### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
