### PR TITLE
Add test to reproduce wrong version of netty-handler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
       - uses: actions/setup-java@v3
         with:
           distribution: temurin

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/test/resources-its/org/openrewrite/maven/RewriteCycloneDxIT/correct_version_of_netty_handler_should_be_reported_in_selenese_runner_java_3e84e8e"]
+	path = src/test/resources-its/org/openrewrite/maven/RewriteCycloneDxIT/correct_version_of_netty_handler_should_be_reported_in_selenese_runner_java_3e84e8e
+	url = git@github.com:vmi/selenese-runner-java.git

--- a/src/test/java/org/openrewrite/maven/RewriteCycloneDxIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteCycloneDxIT.java
@@ -4,6 +4,13 @@ import com.soebes.itf.jupiter.extension.*;
 import com.soebes.itf.jupiter.maven.MavenExecutionResult;
 import org.junit.jupiter.api.Disabled;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
 
 @MavenJupiterExtension
@@ -78,5 +85,29 @@ class RewriteCycloneDxIT {
         assertThat(result).out().warn().isEmpty();
     }
 
+    @MavenTest
+    void correct_version_of_netty_handler_should_be_reported_in_selenese_runner_java_3e84e8e(MavenExecutionResult result) throws IOException, URISyntaxException {
+        assertThat(result)
+                .isSuccessful()
+                .project()
+                .hasTarget()
+                .withFile("selenese-runner-java-4.2.0-cyclonedx.xml")
+                .exists();
 
+        Path seleneseRunnerJavaSBOM = Paths.get("target/maven-it/org/openrewrite/maven/RewriteCycloneDxIT/correct_version_of_netty_handler_should_be_reported_in_selenese_runner_java_3e84e8e/project/target/selenese-runner-java-4.2.0-cyclonedx.xml");
+        byte[] xmlBytes = Files.readAllBytes(seleneseRunnerJavaSBOM);
+        String sbomContents = new String(xmlBytes, Charset.defaultCharset());
+
+
+        String expectedString = "        <component bom-ref=\"pkg:maven/io.netty/netty-handler@4.1.79.Final?type=jar\" type=\"library\">\n" +
+                "            <group>io.netty</group>\n" +
+                "            <name>netty-handler</name>\n" +
+                "            <version>4.1.79.Final</version>\n" +
+                "            <scope>required</scope>\n" +
+                "            <purl>pkg:maven/io.netty/netty-handler@4.1.79.Final?type=jar</purl>\n" +
+                "        </component>";
+
+        assertThat(sbomContents).contains(expectedString);
+
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

- Added a test
- Added a submodule https://github.com/vmi/selenese-runner-java/tree/3e84e8e4e7e06aa1bdacaa8266db00f62ebef559

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

Reproduce #566 .

## Anything in particular you'd like reviewers to focus on?

The version of `io.netty:netty-handler` reported is `4.1.78.Final`, which is incorrect based on `maven-dependency-plugin:3.4.0:tree` as reported [here](https://github.com/chains-project/SBOM-2023/blob/major-revision/sbom-production/results/selenese-runner-java/maven-dependency-tree/tree.json?rgh-link-date=2023-05-31T17%3A48%3A09Z). However, I looked up where this dependency comes from, and it is a direct dependency of https://mvnrepository.com/artifact/io.netty/netty-codec-http/4.1.78.Final. Surprisingly, maven central also reports the version as `4.1.78.Final`.



## Anyone you would like to review specifically?
<!-- @mention them here -->

@joanvr 
## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

I am actually doing a study of SBOM producers and we included your tool in our analysis. You can find the full technical report here - https://arxiv.org/pdf/2303.11102.pdf. We came across this variance in behaviour while looking through different SBOMs.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
