### PR TITLE
Remove unwanted characters from error message

### DIFF
--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -70,7 +70,7 @@ public class ResourceParser {
             sourceFiles.addAll(parseSourceFiles(searchDir, alreadyParsed, ctx));
             List<PlainText> parseFailures = ParsingExecutionContextView.view(ctx).pollParseFailures();
             if (!parseFailures.isEmpty()) {
-                logger.warn("There were problems parsing " + parseFailures.size() + " + sources:");
+                logger.warn("There were problems parsing " + parseFailures.size() + " sources:");
                 for (PlainText parseFailure : parseFailures) {
                     logger.warn("  " + parseFailure.getSourcePath());
                 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
The error message for resources with parse errors.

## What's your motivation?
The error message currently says "There were problems parsing 7 + sources:".

Looking at the git history the plus sign in the output is probably from a string concatenation that made it into the string literal by accident.

### Checklist
n.a.
