### PR TITLE
Jackson 2.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <java.version>1.8</java.version>
 
         <!-- dependencies and plugins -->
-        <jackson-bom.version>2.15.0</jackson-bom.version>
+        <jackson-bom.version>2.15.3</jackson-bom.version>
         <netty.version>4.1.89.Final</netty.version>
         <rocksdbjni.version>8.0.0</rocksdbjni.version>
         <itf-maven.version>0.12.0</itf-maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <java.version>1.8</java.version>
 
         <!-- dependencies and plugins -->
-        <jackson-bom.version>2.15.3</jackson-bom.version>
+        <jackson-bom.version>2.15.2</jackson-bom.version>
         <netty.version>4.1.89.Final</netty.version>
         <rocksdbjni.version>8.0.0</rocksdbjni.version>
         <itf-maven.version>0.12.0</itf-maven.version>


### PR DESCRIPTION
## What's changed?
jackson-bom.version 2.15.0 -> 2.15.2

## What's your motivation?
Vulnerability report.

## Any additional context
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15.1
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15.2
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15.3 (withheld, as BOM missing)
