### PR TITLE
Bump Netty to 4.1.94 & Rsocket to 1.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,9 @@
 
         <!-- dependencies and plugins -->
         <jackson-bom.version>2.15.2</jackson-bom.version>
-        <netty.version>4.1.89.Final</netty.version>
+        <netty.version>4.1.94.Final</netty.version>
         <rocksdbjni.version>8.0.0</rocksdbjni.version>
+        <rsocket.version>1.1.4</rsocket.version>
         <itf-maven.version>0.12.0</itf-maven.version>
         <maven-dependencies.version>3.9.2</maven-dependencies.version>
         <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
@@ -103,7 +104,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.9.2</version>
+                <version>5.9.3</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -118,6 +119,13 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-bom</artifactId>
                 <version>${kotlin.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.rsocket</groupId>
+                <artifactId>rsocket-bom</artifactId>
+                <version>${rsocket.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -215,12 +223,10 @@
         <dependency>
             <groupId>io.rsocket</groupId>
             <artifactId>rsocket-transport-netty</artifactId>
-            <version>1.1.3</version>
         </dependency>
         <dependency>
             <groupId>io.rsocket</groupId>
             <artifactId>rsocket-core</artifactId>
-            <version>1.1.3</version>
         </dependency>
         <dependency>
             <!-- See https://github.com/advisories/GHSA-599f-7c49-w659 -->


### PR DESCRIPTION
## What's changed?
Netty to 4.1.94
Rsocket to 1.1.4

## What's your motivation?
Vulnerability report.

## Any additional context
[Netty 4.1.94.Final released](https://netty.io/news/2023/06/19/4-1-94-Final.html) on 19-Jun-23
[Netty 4.1.93.Final released](https://netty.io/news/2023/05/25/4-1-93-Final.html) on 25-May-23
[Netty 4.1.92.Final released](https://netty.io/news/2023/04/25/4-1-92-Final.html) on 25-Apr-23
[Netty 4.1.91.Final released](https://netty.io/news/2023/04/03/4-1-91-Final.html) on 03-Apr-23
[Netty 4.1.90.Final released](https://netty.io/news/2023/03/14/4-1-90-Final.html) on 14-Mar-23
https://github.com/rsocket/rsocket-java/releases/tag/1.1.4
