### PR TITLE
 Use java.specification.version when no source and target version exists

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -193,7 +193,7 @@ public class MavenMojoProjectParser {
 
     public List<Marker> generateProvenance(MavenProject mavenProject) {
 
-        String javaRuntimeVersion = System.getProperty("java.runtime.version");
+        String javaRuntimeVersion = System.getProperty("java.specification.version");
         String javaVendor = System.getProperty("java.vm.vendor");
 
         String sourceCompatibility = null;

--- a/src/test/java/org/openrewrite/maven/MavenMojoProjectParserTest.java
+++ b/src/test/java/org/openrewrite/maven/MavenMojoProjectParserTest.java
@@ -1,0 +1,34 @@
+package org.openrewrite.maven;
+
+import it.unimi.dsi.fastutil.ints.IntSets;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.rtinfo.internal.DefaultRuntimeInformation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.marker.JavaVersion;
+import org.openrewrite.marker.Marker;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Fabian Krüger
+ */
+class MavenMojoProjectParserTest {
+    @Test
+    @DisplayName("Given No Java version information exists in Maven Then java.specification.version should be used")
+    void givenNoJavaVersionInformationExistsInMavenThenJavaSpecificationVersionShouldBeUsed() {
+        MavenMojoProjectParser sut = new MavenMojoProjectParser(new SystemStreamLog(), null, false, null, new DefaultRuntimeInformation(), false, Collections.EMPTY_LIST, Collections.EMPTY_LIST, -1, null, null, false);
+        List<Marker> markers = sut.generateProvenance(new MavenProject());
+        JavaVersion marker = markers.stream().filter(JavaVersion.class::isInstance).map(JavaVersion.class::cast).findFirst().get();
+        assertThat(marker.getSourceCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
+        assertThat(marker.getTargetCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
+    }
+}


### PR DESCRIPTION

## What's changed?
MavenMojoProjectParser uses `java.specification.version` as default for source and target version.

## What's your motivation?
"Fix": https://github.com/openrewrite/rewrite-maven-plugin/issues/593

### Checklist
- [x] I've added unit tests to cover ~~both~~the positive ~~and negative~~ cases, no dedicated tests existed before
- [x] I've added the license header to any new files through ~~`./gradlew licenseFormat`~~ copied from RewriteRunMojo. Gradle not used in this Module and most classes don't have a license header.
- [x] I've used the IntelliJ auto-formatter on affected files, it formatted only previously existing code so I didn't commit this change
- [ ] I've updated the documentation (if applicable)
