### PR TITLE
Order of parsed Maven modules is sometimes not correct

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -193,7 +193,7 @@ public class MavenMojoProjectParser {
 
     public List<Marker> generateProvenance(MavenProject mavenProject) {
 
-        String javaRuntimeVersion = System.getProperty("java.runtime.version");
+        String javaRuntimeVersion = System.getProperty("java.specification.version");
         String javaVendor = System.getProperty("java.vm.vendor");
 
         String sourceCompatibility = null;

--- a/src/test/java/org/openrewrite/maven/MavenMojoProjectParserTest.java
+++ b/src/test/java/org/openrewrite/maven/MavenMojoProjectParserTest.java
@@ -1,0 +1,34 @@
+package org.openrewrite.maven;
+
+import it.unimi.dsi.fastutil.ints.IntSets;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.rtinfo.internal.DefaultRuntimeInformation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.marker.JavaVersion;
+import org.openrewrite.marker.Marker;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Fabian Krüger
+ */
+class MavenMojoProjectParserTest {
+    @Test
+    @DisplayName("Given No Java version information exists in Maven Then java.specification.version should be used")
+    void givenNoJavaVersionInformationExistsInMavenThenJavaSpecificationVersionShouldBeUsed() {
+        MavenMojoProjectParser sut = new MavenMojoProjectParser(new SystemStreamLog(), null, false, null, new DefaultRuntimeInformation(), false, Collections.EMPTY_LIST, Collections.EMPTY_LIST, -1, null, null, false);
+        List<Marker> markers = sut.generateProvenance(new MavenProject());
+        JavaVersion marker = markers.stream().filter(JavaVersion.class::isInstance).map(JavaVersion.class::cast).findFirst().get();
+        assertThat(marker.getSourceCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
+        assertThat(marker.getTargetCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
+    }
+}

--- a/src/test/java/org/openrewrite/maven/MavenMojoProjectParserTest.java
+++ b/src/test/java/org/openrewrite/maven/MavenMojoProjectParserTest.java
@@ -5,17 +5,28 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.rtinfo.internal.DefaultRuntimeInformation;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.marker.Marker;
+import org.openrewrite.tree.ParsingEventListener;
+import org.openrewrite.tree.ParsingExecutionContextView;
+import org.openrewrite.xml.tree.Xml;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchIllegalArgumentException;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -30,5 +41,112 @@ class MavenMojoProjectParserTest {
         JavaVersion marker = markers.stream().filter(JavaVersion.class::isInstance).map(JavaVersion.class::cast).findFirst().get();
         assertThat(marker.getSourceCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
         assertThat(marker.getTargetCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
+    }
+
+    @Test
+    @DisplayName("order of build files should reflect reactor build order")
+    void orderOfBuildFilesShouldReflectReactorBuildOrder(@TempDir Path tempDir) throws NoSuchMethodException, IOException {
+        MavenMojoProjectParser sut = new MavenMojoProjectParser(new SystemStreamLog(), null, false, null, new DefaultRuntimeInformation(), false, Collections.EMPTY_LIST, Collections.EMPTY_LIST, -1, null, null, false);
+        /*Method collectPoms = MavenMojoProjectParser.class.getDeclaredMethod("collectPoms", MavenProject.class, Set.class);
+        collectPoms.setAccessible(true);
+        Set<Path> allPoms = new LinkedHashSet<>();
+        Object mavenProjects;
+        collectPoms.invoke(sut, mavenProjects, allPoms);*/
+        String pomXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" +
+                "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n" +
+                "    <modelVersion>4.0.0</modelVersion>\n" +
+                "    <groupId>com.example</groupId>\n" +
+                "    <artifactId>multi-module-1</artifactId>\n" +
+                "    <version>1.0.0</version>\n" +
+                "    <packaging>pom</packaging>\n" +
+                "    <properties>\n" +
+                "        <maven.compiler.target>17</maven.compiler.target>\n" +
+                "        <maven.compiler.source>17</maven.compiler.source>\n" +
+                "        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n" +
+                "    </properties>\n" +
+                "    <dependencies>\n" +
+                "        <dependency>\n" +
+                "            <groupId>org.springframework.boot</groupId>\n" +
+                "            <artifactId>spring-boot-starter</artifactId>\n" +
+                "            <version>3.1.1</version>\n" +
+                "        </dependency>\n" +
+                "    </dependencies>\n" +
+                "    <modules>\n" +
+                "        <module>module-a</module>\n" +
+                "        <module>module-b</module>\n" +
+                "    </modules>\n" +
+                "</project>";
+
+        String moduleAPom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" +
+                "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n" +
+                "    <modelVersion>4.0.0</modelVersion>\n" +
+                "    <parent>\n" +
+                "        <groupId>com.example</groupId>\n" +
+                "        <artifactId>multi-module-1</artifactId>\n" +
+                "        <version>1.0.0</version>\n" +
+                "    </parent>\n" +
+                "    <artifactId>module-a</artifactId>\n" +
+                "    <dependencies>\n" +
+                "        <dependency>\n" +
+                "            <groupId>com.example</groupId>\n" +
+                "            <artifactId>module-b</artifactId>\n" +
+                "            <version>${project.version}</version>\n" +
+                "        </dependency>\n" +
+                "    </dependencies>\n" +
+                "</project>";
+
+        String moduleBPom = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" +
+                "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n" +
+                "    <modelVersion>4.0.0</modelVersion>\n" +
+                "    <parent>\n" +
+                "        <groupId>com.example</groupId>\n" +
+                "        <artifactId>multi-module-1</artifactId>\n" +
+                "        <version>1.0.0</version>\n" +
+                "    </parent>\n" +
+                "    <artifactId>module-b</artifactId>\n" +
+                "</project>";
+
+
+        Path rootPomFile = tempDir.resolve("pom.xml");
+        Files.write(rootPomFile, pomXml.getBytes());
+
+        Path aPath = tempDir.resolve("module-a");
+        aPath.toFile().mkdirs();
+        Path aFile = aPath.resolve("pom.xml");
+        Files.write(aFile, moduleAPom.getBytes());
+
+        Path bPath = tempDir.resolve("module-b");
+        Path bFile = bPath.resolve("pom.xml");
+        bPath.toFile().mkdirs();
+        Files.write(bFile, moduleBPom.getBytes());
+
+        MavenProject rootProject = new MavenProject();// mock(MavenProject.class);
+        MavenProject aProject = new MavenProject();
+        MavenProject bProject = new MavenProject();
+
+        List<MavenProject> mavenProjects = new ArrayList<>();
+        mavenProjects.add(bProject);
+        mavenProjects.add(rootProject);
+        mavenProjects.add(aProject);
+        Map<MavenProject, List<Marker>> markers = new LinkedHashMap<>();
+        ExecutionContext ctx = new InMemoryExecutionContext(Assertions::fail);
+        List<String> capturedResourcePaths = new ArrayList<>();
+        new ParsingExecutionContextView(ctx).setParsingListener((input, sourceFile) -> {
+            capturedResourcePaths.add(sourceFile.getSourcePath().toString());
+        });
+//        Map<MavenProject, Xml.Document> mavenProjectDocumentMap = sut.parseMaven(mavenProjects, markers, ctx);
+        MavenProject mavenProject = new MavenProject();
+        mavenProject.setFile(rootPomFile.toFile());
+        sut.parseMaven(mavenProject, new ArrayList<>(), ctx);
+
+        assertThat(capturedResourcePaths.get(0)).isEqualTo("pom.xml");
+        assertThat(capturedResourcePaths.get(1)).isEqualTo("module-b/pom.xml");
+        assertThat(capturedResourcePaths.get(2)).isEqualTo("module-a/pom.xml");
     }
 }


### PR DESCRIPTION
## What's changed?
The method `MavenMojoProjectParser#collectPoms` adds the poms in the wrong order.
I think the problem can be fixed by using `MavenSession#getProjects()` instead.

## What's your motivation?
- #600 

## Anything in particular you'd like reviewers to focus on?
I need some advice on how you think this should be tested.

My preferred approach would have been to test the method `collectPoms` and verify that the poms added to the `paths` exactly in the order as returned by `MavenSession#getProjects()`.
I would have liked to pass in a Mock for `MavenSession` and verify the call.
But there are some problems with this approach:
- The method is private, I would have been nasty and used reflection to make it accessible.
- No Mockito is available

And an additional test that verifies the expected behavior of `MavenSession#getProjects()`- the correct ordering

The next (additional) way to test this I'd see is an integration test for the plugin itself and verifying the parsing events. I did not understand `RewriteRunIT` and would be interested in your opinion of how to approach this  before proceeding.

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
By decoupling the `MavenMojoProject` parser from `File` and Maven unittest would become easier. 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
