### PR TITLE
Update the pom.xml so auto-generation works for docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
                     </reportSet>
                 </reportSets>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-report-plugin</artifactId>
+                <version>3.9.0</version>
+            </plugin>
         </plugins>
     </reporting>
 
@@ -434,10 +439,6 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>${maven-plugin-tools.version}</version>
                 <executions>
-                    <execution>
-                        <id>default-descriptor</id>
-                        <phase>process-classes</phase>
-                    </execution>
                     <execution>
                         <id>generate-helpmojo</id>
                         <goals>

--- a/src/test/java/org/openrewrite/maven/RewriteDryRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDryRunIT.java
@@ -42,7 +42,7 @@ class RewriteDryRunIT {
                 .isSuccessful()
                 .out()
                 .warn()
-                .anySatisfy(line -> assertThat(line).contains("org.openrewrite.java.cleanup.SimplifyBooleanExpression"));
+                .anySatisfy(line -> assertThat(line).contains("org.openrewrite.staticanalysis.SimplifyBooleanExpression"));
     }
 
     @MavenTest
@@ -51,7 +51,7 @@ class RewriteDryRunIT {
                 .isSuccessful()
                 .out()
                 .info()
-                .anySatisfy(line -> assertThat(line).contains("Using active recipe(s) [com.example.RewriteDryRunIT.CodeCleanup, org.openrewrite.java.format.AutoFormat, org.openrewrite.java.cleanup.SimplifyBooleanExpression]"));
+                .anySatisfy(line -> assertThat(line).contains("Using active recipe(s) [com.example.RewriteDryRunIT.CodeCleanup, org.openrewrite.java.format.AutoFormat, org.openrewrite.staticanalysis.SimplifyBooleanExpression]"));
     }
 
     @MavenTest

--- a/src/test/java/org/openrewrite/maven/RewriteRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunIT.java
@@ -37,7 +37,7 @@ class RewriteRunIT {
                 .isSuccessful()
                 .out()
                 .warn()
-                .anySatisfy(line -> assertThat(line).contains("org.openrewrite.java.cleanup.SimplifyBooleanExpression"));
+                .anySatisfy(line -> assertThat(line).contains("org.openrewrite.staticanalysis.SimplifyBooleanExpression"));
     }
 
     @MavenTest

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/pom.xml
@@ -33,6 +33,13 @@
                         ${maven.multiModuleProjectDirectory}/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/rewrite.yml
                     </configLocation>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-static-analysis</artifactId>
+                        <version>1.0.4</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/rewrite.yml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/rewrite.yml
@@ -2,6 +2,6 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: com.example.RewriteDryRunIT.CodeCleanup
 recipeList:
-  - org.openrewrite.java.cleanup.SimplifyBooleanExpression
-  - org.openrewrite.java.cleanup.SimplifyBooleanReturn
-  - org.openrewrite.java.cleanup.UnnecessaryParentheses
+  - org.openrewrite.staticanalysis.SimplifyBooleanExpression
+  - org.openrewrite.staticanalysis.SimplifyBooleanReturn
+  - org.openrewrite.staticanalysis.UnnecessaryParentheses

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/recipe_order/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/recipe_order/pom.xml
@@ -25,7 +25,7 @@
                     <activeRecipes>
                         <recipe>com.example.RewriteDryRunIT.CodeCleanup</recipe>
                         <recipe>org.openrewrite.java.format.AutoFormat</recipe>
-                        <recipe>org.openrewrite.java.cleanup.SimplifyBooleanExpression</recipe>
+                        <recipe>org.openrewrite.staticanalysis.SimplifyBooleanExpression</recipe>
                     </activeRecipes>
                     <configLocation>
                         ${maven.multiModuleProjectDirectory}/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/recipe_order/rewrite.yml

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/recipe_order/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/recipe_order/pom.xml
@@ -31,6 +31,13 @@
                         ${maven.multiModuleProjectDirectory}/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/recipe_order/rewrite.yml
                     </configLocation>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-static-analysis</artifactId>
+                        <version>1.0.4</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/recipe_order/rewrite.yml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/recipe_order/rewrite.yml
@@ -2,6 +2,6 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: com.example.RewriteDryRunIT.CodeCleanup
 recipeList:
-  - org.openrewrite.java.cleanup.SimplifyBooleanExpression
-  - org.openrewrite.java.cleanup.SimplifyBooleanReturn
-  - org.openrewrite.java.cleanup.UnnecessaryParentheses
+  - org.openrewrite.staticanalysis.SimplifyBooleanExpression
+  - org.openrewrite.staticanalysis.SimplifyBooleanReturn
+  - org.openrewrite.staticanalysis.UnnecessaryParentheses

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/pom.xml
@@ -33,6 +33,13 @@
                         ${maven.multiModuleProjectDirectory}/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/rewrite.yml
                     </configLocation>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-static-analysis</artifactId>
+                        <version>1.0.4</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/rewrite.yml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/rewrite.yml
@@ -2,6 +2,6 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: com.example.RewriteRunIT.CodeCleanup
 recipeList:
-  - org.openrewrite.java.cleanup.SimplifyBooleanExpression
-  - org.openrewrite.java.cleanup.SimplifyBooleanReturn
-  - org.openrewrite.java.cleanup.UnnecessaryParentheses
+  - org.openrewrite.staticanalysis.SimplifyBooleanExpression
+  - org.openrewrite.staticanalysis.SimplifyBooleanReturn
+  - org.openrewrite.staticanalysis.UnnecessaryParentheses


### PR DESCRIPTION
Not much code here - but hours of investigation >_<

* https://stackoverflow.com/questions/76757630/maven-plugin-plugin-descriptor-goal-does-not-generate-mojo-description-documenta 
* https://stackoverflow.com/questions/76765750/plugin-info-html-file-not-being-generated-when-running-maven-site

We can then run `mvn process-classes` and then `mvn site` to get auto-generated documentation of our plugins.