### PR TITLE
Deploy plugin docs to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,9 +2,6 @@
 name: Deploy plugin docs to Pages
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     tags:
       - v*

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,11 +1,13 @@
 # Simple workflow for deploying static content to GitHub Pages
 name: Deploy plugin docs to Pages
 
-#TODO Limit to tags such that we don't deploy on every push
-#on:
-#  push:
-#    tags:
-#      - v*
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    tags:
+      - v*
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,12 +36,8 @@ jobs:
           cache: maven
       - name: site
         run: ./mvnw --show-version --no-transfer-progress --update-snapshots clean site --file=pom.xml --fail-at-end --batch-mode -Dstyle.color=always  -Ddependency-check.skip=true
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
         with:
           path: target/site
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+      - uses: actions/deploy-pages@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,47 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy plugin docs to Pages
+
+#TODO Limit to tags such that we don't deploy on every push
+#on:
+#  push:
+#    tags:
+#      - v*
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  pages:
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v3.11.0
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+      - name: site
+        run: ./mvnw --show-version --no-transfer-progress --update-snapshots clean site --file=pom.xml --fail-at-end --batch-mode -Dstyle.color=always  -Ddependency-check.skip=true
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: target/site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,10 +28,8 @@ jobs:
       url: ${{steps.deployment.outputs.page_url}}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v3.11.0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <maven>3.3.1</maven>
     </prerequisites>
 
-    <url>https://github.com/openrewrite/rewrite-maven-plugin</url>
+    <url>https://openrewrite.github.io/rewrite-maven-plugin/</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
## What's changed?
Deploy plugin docs to GitHub Pages at 
https://openrewrite.github.io/rewrite-maven-plugin/plugin-info.html

## What's your motivation?
We want to link to the generated docs, such that they are always up to date.

## Anything in particular you'd like reviewers to focus on?
Would we want to swap for a different style?
Would we want to limit produced pages through a site.xml?

## Any additional context
Intended to mostly replace: https://docs.openrewrite.org/reference/rewrite-maven-plugin
https://github.com/openrewrite/rewrite-docs/blob/master/reference/rewrite-maven-plugin.md