### PR TITLE
Dump invalid message configuration

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -226,9 +226,14 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
             List<Validated.Invalid<Object>> failedValidations = validations.stream().map(Validated::failures)
                     .flatMap(Collection::stream).collect(toList());
             if (!failedValidations.isEmpty()) {
-                failedValidations.forEach(failedValidation -> getLog().error(
-                        "Recipe validation error in " + failedValidation.getProperty() + ": " +
-                        failedValidation.getMessage(), failedValidation.getException()));
+                failedValidations.forEach(failedValidation -> {
+                    if (getLog().isDebugEnabled()) {
+                        getLog().debug("Recipe " + recipe + " invalid");
+                    }
+                    getLog().error(
+                            "Recipe validation error in " + failedValidation.getProperty() + ": " +
+                                    failedValidation.getMessage(), failedValidation.getException());
+                });
                 if (failOnInvalidActiveRecipes) {
                     throw new MojoExecutionException("Recipe validation errors detected as part of one or more activeRecipe(s). Please check error logs.");
                 } else {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Dump invalid recipes if maven debug log is enabled

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

Try to identify invalid recipes in a large refactor project

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
