### PR TITLE
Log parsed files to Maven debug log

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: bump-rewrite-properties-to-releases
         run: |
-          ./mvnw versions:update-properties -DincludeProperties=rewrite.version,rewrite.python.version -DallowDowngrade=true
+          ./mvnw versions:update-properties -DincludeProperties=rewrite.version,rewrite.all.version,rewrite.python.version -DallowDowngrade=true
           git diff-index --quiet HEAD pom.xml || git commit -m "Bump rewrite.version properties" pom.xml && rm -f pom.xml.versionsBackup
 
       - name: publish-release

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
     <properties>
         <!-- Pinned versions, as RELEASE would make it into the published pom.xml -->
         <rewrite.version>8.2.0-SNAPSHOT</rewrite.version>
+        <rewrite.all.version>1.1.0-SNAPSHOT</rewrite.all.version>
         <rewrite.python.version>1.1.0-SNAPSHOT</rewrite.python.version>
 
         <!-- using 'ssh' url scheme by default, which assumes a human is performing git operations leveraging an ssh key -->
@@ -159,6 +160,11 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-all</artifactId>
+            <version>${rewrite.all.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-java</artifactId>

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -39,7 +39,10 @@ import org.openrewrite.ipc.http.HttpSender;
 import org.openrewrite.ipc.http.HttpUrlConnectionSender;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.marker.*;
+import org.openrewrite.maven.ux.MavenLogProgressBar;
+import org.openrewrite.maven.ux.ProgressBarParsingEventListener;
 import org.openrewrite.style.NamedStyles;
+import org.openrewrite.tree.ParsingExecutionContextView;
 import org.openrewrite.xml.tree.Xml;
 
 import java.io.File;
@@ -141,7 +144,10 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
     }
 
     protected ExecutionContext executionContext() {
-        return new InMemoryExecutionContext(t -> getLog().debug(t));
+        InMemoryExecutionContext ctx = new InMemoryExecutionContext(t -> getLog().debug(t));
+        ParsingExecutionContextView view = ParsingExecutionContextView.view(ctx);
+        view.setParsingListener(new ProgressBarParsingEventListener(new MavenLogProgressBar(getLog())));
+        return view;
     }
 
     protected Path getBuildRoot() {

--- a/src/main/java/org/openrewrite/maven/ux/MavenLogProgressBar.java
+++ b/src/main/java/org/openrewrite/maven/ux/MavenLogProgressBar.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.ux;
+
+import org.apache.maven.plugin.logging.Log;
+import org.openrewrite.NoopProgressBar;
+import org.openrewrite.ProgressBar;
+import org.openrewrite.internal.lang.Nullable;
+
+public class MavenLogProgressBar extends NoopProgressBar {
+
+    private final Log log;
+
+    public MavenLogProgressBar(Log log) {
+        this.log = log;
+    }
+
+    @Override
+    public ProgressBar setExtraMessage(String extraMessage) {
+        log.info(extraMessage);
+        return this;
+    }
+
+    @Override
+    public void intermediateResult(@Nullable String message) {
+        log.debug(message);
+    }
+
+    @Override
+    public void finish(String message) {
+        log.info(message);
+    }
+
+}

--- a/src/main/java/org/openrewrite/maven/ux/ProgressBarParsingEventListener.java
+++ b/src/main/java/org/openrewrite/maven/ux/ProgressBarParsingEventListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.ux;
+
+import org.openrewrite.Parser;
+import org.openrewrite.ProgressBar;
+import org.openrewrite.SourceFile;
+import org.openrewrite.tree.ParsingEventListener;
+
+public class ProgressBarParsingEventListener implements ParsingEventListener {
+
+    private final ProgressBar progressBar;
+
+    public ProgressBarParsingEventListener(ProgressBar progressBar) {
+        this.progressBar = progressBar;
+    }
+
+    @Override
+    public void parsed(Parser.Input input, SourceFile sourceFile) {
+        progressBar.intermediateResult("Parsed " + input.getPath());
+    }
+}


### PR DESCRIPTION
## What's changed?
We now debug log parsed files through the progress bar interface added to rewrite-all, such that we can optionally swap in a different 

## What's your motivation?
Fixes #544

## Anything in particular you'd like reviewers to focus on?
Right now rewrite-all has runtime only dependencies; do we expect that to stay that way?
If those runtime dependencies change into transitive dependencies that could increase the cumulative runtime size here.

## Have you considered any alternatives or workarounds?
This minimal implementation for now only prints parsed files when running the OpenRewrite parsers, as Maven itself already logs the session, projects and mojos. No need to duplicate that here.