### PR TITLE
Pass MavenExecutionContextView into MavenParser

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -409,7 +409,8 @@ public class MavenMojoProjectParser {
 
         List<SourceFile> mavens = mavenParserBuilder
                 .build()
-                .parse(allPoms, baseDir, ctx).collect(toList());
+                .parse(allPoms, baseDir, mavenExecutionContext)
+                .collect(toList());
 
         if (logger.isDebugEnabled()) {
             logDebug(topLevelProject, "Base directory : '" + baseDir + "'");


### PR DESCRIPTION
This view containing the Maven settings above is only created, not used or passed down.