### PR TITLE
Fix indentation of available recipes output (#630)

### DIFF
--- a/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
@@ -124,7 +124,7 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
     }
 
     private void writeRecipeDescriptor(RecipeDescriptor rd, boolean verbose, int currentRecursionLevel, int indentLevel) {
-        String indent = StringUtils.repeat("    ", indentLevel * 4);
+        String indent = StringUtils.repeat("    ", indentLevel);
         if (currentRecursionLevel <= recursion) {
             if (verbose) {
 


### PR DESCRIPTION
## What's changed?
Indentation of discover mojo is now as expected.

![grafik](https://github.com/openrewrite/rewrite-maven-plugin/assets/406876/833b197e-e6ab-44c2-af23-e002c8d34777)

## What's your motivation?
Part of #630.