### PR TITLE
Ignore Tycho generated POMs

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -494,6 +494,14 @@ public class MavenMojoProjectParser {
         if (pomPath.endsWith(".flattened-pom.xml")) {
             return mavenProject.getBasedir().toPath().resolve("pom.xml");
         }
+        // org.eclipse.tycho:tycho-packaging-plugin:update-consumer-pom produces a synthetic pom
+        if (pomPath.endsWith(".tycho-consumer-pom.xml")) {
+            Path normalPom = mavenProject.getBasedir().toPath().resolve("pom.xml");
+            // check for existence of the POM, since Tycho can work pom-less
+            if (Files.isReadable(normalPom) && Files.isRegularFile(normalPom)) {
+                return normalPom;
+            }
+        }
         return pomPath;
     }
 


### PR DESCRIPTION
Eclipse Tycho produces artificial Maven POMs during the build, which should be ignored by the POM scanner.

Fixes #634.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Ignore temporary POMs generated by Eclipse Tycho during the scan for POMs.
The debug log now shows the real POMs being picked up during the scan (compare to issue):
```
[DEBUG] Project [eclipse-cs Maven Parent] Base directory : 'C:\dev\eclipse-cs\git\eclipse-cs'
[DEBUG] Project [eclipse-cs Maven Parent]   Collected Maven POM : 'C:\dev\eclipse-cs\git\eclipse-cs\pom.xml'
[DEBUG] Project [eclipse-cs Maven Parent]   Collected Maven POM : 'C:\dev\eclipse-cs\git\eclipse-cs\net.sf.eclipsecs.branding\pom.xml'
[DEBUG] Project [eclipse-cs Maven Parent]   Collected Maven POM : 'C:\dev\eclipse-cs\git\eclipse-cs\net.sf.eclipsecs.checkstyle\pom.xml'
[DEBUG] Project [eclipse-cs Maven Parent]   Collected Maven POM : 'C:\dev\eclipse-cs\git\eclipse-cs\net.sf.eclipsecs.core\pom.xml'
[DEBUG] Project [eclipse-cs Maven Parent]   Collected Maven POM : 'C:\dev\eclipse-cs\git\eclipse-cs\net.sf.eclipsecs.doc\pom.xml'
[DEBUG] Project [eclipse-cs Maven Parent]   Collected Maven POM : 'C:\dev\eclipse-cs\git\eclipse-cs\net.sf.eclipsecs.sample\pom.xml'
[DEBUG] Project [eclipse-cs Maven Parent]   Collected Maven POM : 'C:\dev\eclipse-cs\git\eclipse-cs\net.sf.eclipsecs.ui\pom.xml'
[DEBUG] Project [eclipse-cs Maven Parent]   Collected Maven POM : 'C:\dev\eclipse-cs\git\eclipse-cs\net.sf.eclipsecs-feature\pom.xml'
[DEBUG] Project [eclipse-cs Maven Parent]   Collected Maven POM : 'C:\dev\eclipse-cs\git\eclipse-cs\net.sf.eclipsecs-updatesite\pom.xml'
```

## What's your motivation?
#634 