### PR TITLE
Ignore Maven POM cache warning in test

### DIFF
--- a/src/test/java/org/openrewrite/maven/RewriteCycloneDxIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteCycloneDxIT.java
@@ -78,7 +78,12 @@ class RewriteCycloneDxIT {
                 .withFile("b-1.0-cyclonedx.xml")
                 .exists();
 
-        assertThat(result).out().warn().isEmpty();
+        // ignore Maven POM cache warning, it may appear on some systems
+        // https://github.com/openrewrite/rewrite-maven-plugin/issues/636
+        assertThat(result).out().warn()
+                .filteredOn(warn -> !"Unable to initialize RocksdbMavenPomCache, falling back to InMemoryMavenPomCache"
+                        .equals(warn))
+                .isEmpty();
     }
 
     @MavenTest


### PR DESCRIPTION
Fixes #636.

## What's changed?
Just ignores a warning during test, which may appear on some systems, but not on all.