### PR TITLE
Add kotlin parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <!-- Pinned versions, as RELEASE would make it into the published pom.xml -->
         <rewrite.version>8.8.0-SNAPSHOT</rewrite.version>
         <rewrite.python.version>1.2.0-SNAPSHOT</rewrite.python.version>
+        <rewrite.kotlin.version>1.5.0-SNAPSHOT</rewrite.kotlin.version>
 
         <!-- using 'ssh' url scheme by default, which assumes a human is performing git operations leveraging an ssh key -->
         <developerConnectionUrl>scm:git:ssh://git@github.com/openrewrite/rewrite-maven-plugin.git
@@ -208,7 +209,11 @@
             <artifactId>rewrite-python</artifactId>
             <version>${rewrite.python.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-kotlin</artifactId>
+            <version>${rewrite.kotlin.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -378,9 +378,9 @@ public class MavenMojoProjectParser {
 
         // scan Kotlin files
         String kotlinSourceDir = getKotlinDirectory(mavenProject.getBuild().getSourceDirectory());
-        List<Path> mainKotlinSources = (kotlinSourceDir != null) ? listKotlinSources(mavenProject.getBasedir().toPath().resolve(kotlinSourceDir)) : Collections.emptyList();
+        List<Path> testKotlinSources = (kotlinSourceDir != null) ? listKotlinSources(mavenProject.getBasedir().toPath().resolve(kotlinSourceDir)) : Collections.emptyList();
 
-        alreadyParsed.addAll(mainKotlinSources);
+        alreadyParsed.addAll(testKotlinSources);
 
         Stream<? extends SourceFile> cus = Stream.of(javaParserBuilder)
                 .map(JavaParser.Builder::build)
@@ -388,7 +388,7 @@ public class MavenMojoProjectParser {
 
         Stream<? extends SourceFile> kcus = Stream.of(kotlinParserBuilder)
                 .map(KotlinParser.Builder::build)
-                .flatMap(parser -> parser.parse(mainKotlinSources, baseDir, ctx));
+                .flatMap(parser -> parser.parse(testKotlinSources, baseDir, ctx));
 
         List<Marker> markers = new ArrayList<>(projectProvenance);
         markers.add(sourceSet("test", testDependencies, typeCache));
@@ -397,7 +397,7 @@ public class MavenMojoProjectParser {
         logDebug(mavenProject, "Scanned " + testJavaSources.size() + " java source files in test scope.");
 
         Stream<SourceFile> parsedKotlin = kcus.map(addProvenance(baseDir, markers, null));
-        logDebug(mavenProject, "Scanned " + mainKotlinSources.size() + " kotlin source files in main scope.");
+        logDebug(mavenProject, "Scanned " + testKotlinSources.size() + " kotlin source files in main scope.");
 
         Stream<SourceFile> sourceFiles = Stream.concat(parsedJava, parsedKotlin);
 

--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -55,11 +55,14 @@ public class ResourceParser {
      */
     private final JavaParser.Builder<? extends JavaParser, ?> javaParserBuilder;
 
+    private final KotlinParser.Builder kotlinParserBuilder;
+
     public ResourceParser(Path baseDir, Log logger, Collection<String> exclusions, Collection<String> plainTextMasks, int sizeThresholdMb, Collection<Path> excludedDirectories,
-                          JavaParser.Builder<? extends JavaParser, ?> javaParserBuilder) {
+                          JavaParser.Builder<? extends JavaParser, ?> javaParserBuilder, KotlinParser.Builder kotlinParserBuilder) {
         this.baseDir = baseDir;
         this.logger = logger;
         this.javaParserBuilder = javaParserBuilder;
+        this.kotlinParserBuilder = kotlinParserBuilder;
         this.exclusions = pathMatchers(baseDir, exclusions);
         this.sizeThresholdMb = sizeThresholdMb;
         this.excludedDirectories = excludedDirectories;

--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -22,6 +22,7 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.hcl.HclParser;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.json.JsonParser;
+import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.properties.PropertiesParser;
 import org.openrewrite.protobuf.ProtoParser;
 import org.openrewrite.python.PythonParser;
@@ -148,6 +149,9 @@ public class ResourceParser {
         PythonParser pythonParser = PythonParser.builder().build();
         List<Path> pythonPaths = new ArrayList<>();
 
+        KotlinParser kotlinParser = KotlinParser.builder().build();
+        List<Path> kotlinPaths = new ArrayList<>();
+
         HclParser hclParser = HclParser.builder().build();
         List<Path> hclPaths = new ArrayList<>();
 
@@ -172,6 +176,8 @@ public class ResourceParser {
                 protoPaths.add(path);
             } else if (pythonParser.accept(path)) {
                 pythonPaths.add(path);
+            } else if (kotlinParser.accept(path)) {
+                kotlinPaths.add(path);
             } else if (hclParser.accept(path)) {
                 hclPaths.add(path);
             } else if (quarkParser.accept(path)) {
@@ -212,6 +218,11 @@ public class ResourceParser {
         if (!pythonPaths.isEmpty()) {
             sourceFiles = Stream.concat(sourceFiles, (Stream<S>) pythonParser.parse(pythonPaths, baseDir, ctx));
             alreadyParsed.addAll(pythonPaths);
+        }
+
+        if (!kotlinPaths.isEmpty()) {
+            sourceFiles = Stream.concat(sourceFiles, (Stream<S>) kotlinParser.parse(kotlinPaths, baseDir, ctx));
+            alreadyParsed.addAll(kotlinPaths);
         }
 
         if (!hclPaths.isEmpty()) {


### PR DESCRIPTION
Add kotlin parser to support Maven projects.

Verified in https://github.com/vert-x3/vertx-client-services and running recipe `org.openrewrite.kotlin.format.AutoFormat` and `org.openrewrite.java.ChangeType`, it works well.

