### PR TITLE
fixed link to quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This `README` may not have the most up-to-date documentation. For the most up-to
 
 - [Auto-generated maven plugin documentation](https://openrewrite.github.io/rewrite-maven-plugin/plugin-info.html)
 - [Maven Plugin Configuration](https://docs.openrewrite.org/reference/rewrite-maven-plugin)
-- [OpenRewrite Quickstart Guide](https://docs.openrewrite.org/getting-started/getting-started)
+- [OpenRewrite Quickstart Guide](https://docs.openrewrite.org/running-recipes/getting-started)
 
 To configure, add the plugin to your POM:
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
The link to the OpenRewrite Quickstart Guide was broken.

## What's your motivation?
I want people to find the correct website in the README.

### Checklist
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
