### PR TITLE
Avoid calling parsers when there are no source files

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -323,13 +323,13 @@ public class MavenMojoProjectParser {
         javaParserBuilder.classpath(dependencies).typeCache(typeCache);
         kotlinParserBuilder.classpath(dependencies).typeCache(new JavaTypeCache());
 
-        Stream<? extends SourceFile> cus = Stream.of(javaParserBuilder)
-                .map(JavaParser.Builder::build)
-                .flatMap(parser -> parser.parse(mainJavaSources, baseDir, ctx));
+        Stream<? extends SourceFile> cus = mainJavaSources.isEmpty() ? Stream.empty()
+                : Stream.of(javaParserBuilder).map(JavaParser.Builder::build)
+                        .flatMap(parser -> parser.parse(mainJavaSources, baseDir, ctx));
 
-        Stream<? extends SourceFile> kcus = Stream.of(kotlinParserBuilder)
-                .map(KotlinParser.Builder::build)
-                .flatMap(parser -> parser.parse(mainKotlinSources, baseDir, ctx));
+        Stream<? extends SourceFile> kcus = mainKotlinSources.isEmpty() ? Stream.empty()
+                : Stream.of(kotlinParserBuilder).map(KotlinParser.Builder::build)
+                        .flatMap(parser -> parser.parse(mainKotlinSources, baseDir, ctx));
 
         List<Marker> mainProjectProvenance = new ArrayList<>(projectProvenance);
         mainProjectProvenance.add(sourceSet("main", dependencies, typeCache));
@@ -382,13 +382,13 @@ public class MavenMojoProjectParser {
 
         alreadyParsed.addAll(testKotlinSources);
 
-        Stream<? extends SourceFile> cus = Stream.of(javaParserBuilder)
-                .map(JavaParser.Builder::build)
-                .flatMap(parser -> parser.parse(testJavaSources, baseDir, ctx));
+        Stream<? extends SourceFile> cus = testJavaSources.isEmpty() ? Stream.empty()
+                : Stream.of(javaParserBuilder).map(JavaParser.Builder::build)
+                        .flatMap(parser -> parser.parse(testJavaSources, baseDir, ctx));
 
-        Stream<? extends SourceFile> kcus = Stream.of(kotlinParserBuilder)
-                .map(KotlinParser.Builder::build)
-                .flatMap(parser -> parser.parse(testKotlinSources, baseDir, ctx));
+        Stream<? extends SourceFile> kcus = testKotlinSources.isEmpty() ? Stream.empty()
+                : Stream.of(kotlinParserBuilder).map(KotlinParser.Builder::build)
+                        .flatMap(parser -> parser.parse(testKotlinSources, baseDir, ctx));
 
         List<Marker> markers = new ArrayList<>(projectProvenance);
         markers.add(sourceSet("test", testDependencies, typeCache));


### PR DESCRIPTION
With empty lists of main or test, Java or Kotlin files avoid invoking the parsers completely. That's more performant and avoids any bad side effects during initialization of the parsers.

Fixes #658.

## Anything in particular you'd like reviewers to focus on?
You may want to reformat, I used the Eclipse formatter.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
