### PR TITLE
Improve quark parsing message

### DIFF
--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -118,8 +118,8 @@ public class ResourceParser {
                 if (!attrs.isOther() && !attrs.isSymbolicLink() &&
                     !alreadyParsed.contains(file) && !isExcluded(file)) {
                     if (isOverSizeThreshold(attrs.size())) {
-                        logger.info("Parsing as quark " + file + " as its size " + attrs.size() / (1024L * 1024L) +
-                                    "Mb exceeds size threshold " + sizeThresholdMb + "Mb");
+                        logger.info("Not parsing quark " + file + " as its size " + attrs.size() / (1024L * 1024L) +
+                                    " MB exceeds size threshold " + sizeThresholdMb + " MB");
                         quarkPaths.add(file);
                     } else if (isParsedAsPlainText(file)) {
                         plainTextPaths.add(file);


### PR DESCRIPTION
Fixes #671.

As suggested in the discussion, change the message to indicate that quark files are not parsed.

Also change the unit from "Mb" to "MB", since "Mb" indicates Megabit. Add a blank between numbers and unit for readability and to be consistent with output in other parts of the code.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Only the log message which is emitted for large non parseable files.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Clarifies the confusion described in #671.
