### PR TITLE
Avoid annotation processor warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
           server-id: ossrh
           settings-path: ${{ github.workspace }}

--- a/pom.xml
+++ b/pom.xml
@@ -459,6 +459,7 @@
                     <compilerArgs>
                         <arg>-Xlint:deprecation</arg>
                         <arg>-Xlint:unchecked</arg>
+                        <arg>-proc:full</arg>
                     </compilerArgs>
                     <source>${java.version}</source>
                     <target>${java.version}</target>


### PR DESCRIPTION
Java 21+ warns about active annotation processors, unless the compiler has been explicitly configured to accept them.

See https://bugs.openjdk.org/browse/JDK-8310061

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Remove this warning from the build process, when running Maven on Java 21+:
![grafik](https://github.com/openrewrite/rewrite-maven-plugin/assets/406876/e50d79d2-645f-460e-819d-938ebada04ed)

Doesn't have any side effects on older JDKs.

Further references: https://inside.java/2023/07/29/quality-heads-up/ or https://github.com/khmarbaise/jdk21
