### PR TITLE
Reuse ExecutionContext for ResourceParser

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -182,7 +182,7 @@ public class MavenMojoProjectParser {
         // todo, add styles from autoDetect
         KotlinParser.Builder kotlinParserBuilder = KotlinParser.builder();
         ResourceParser rp = new ResourceParser(baseDir, logger, exclusions, plainTextMasks, sizeThresholdMb, pathsToOtherMavenProjects(mavenProject),
-                javaParserBuilder.clone(), kotlinParserBuilder.clone());
+                javaParserBuilder.clone(), kotlinParserBuilder.clone(), ctx);
 
         sourceFiles = Stream.concat(sourceFiles, processMainSources(mavenProject, javaParserBuilder.clone(), kotlinParserBuilder.clone(), rp, projectProvenance, alreadyParsed, ctx));
         sourceFiles = Stream.concat(sourceFiles, processTestSources(mavenProject, javaParserBuilder.clone(), kotlinParserBuilder.clone(), rp, projectProvenance, alreadyParsed, ctx));


### PR DESCRIPTION
## What's changed?
Pass the existing `ExecutionContext` into `ResourceParser`, instead of creating a new `InMemoryExecutionContext`.

## What's your motivation?
Reuse any `ParsingEventListeners` or `Consumer<Throwable>` registered on the original ExecutionContext.
Fixes #622

## Any additional context
- #622