### PR TITLE
Kotlin source dir parsing bugfix

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -392,7 +392,7 @@ public class MavenMojoProjectParser {
         alreadyParsed.addAll(testJavaSources);
 
         // scan Kotlin files
-        String kotlinSourceDir = getKotlinDirectory(mavenProject.getBuild().getSourceDirectory());
+        String kotlinSourceDir = getKotlinDirectory(mavenProject.getBuild().getTestSourceDirectory());
         List<Path> testKotlinSources = (kotlinSourceDir != null) ? listKotlinSources(mavenProject.getBasedir().toPath().resolve(kotlinSourceDir)) : Collections.emptyList();
         alreadyParsed.addAll(testKotlinSources);
 


### PR DESCRIPTION
Fix bug where Kotlin test source parsing actually parsed main dir a second time, and test sources were later parsed as additional resources

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->


## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->


## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->


## Anyone you would like to review specifically?
<!-- @mention them here -->


## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->


## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->


### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
