### PR TITLE
Revert to Java 17 after openrewrite/rewrite#3826

### DIFF
--- a/.github/workflows/bump-snapshots.yml
+++ b/.github/workflows/bump-snapshots.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 17
           cache: maven
           server-id: ossrh
           settings-path: ${{ github.workspace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 17
           cache: maven
           server-id: ossrh
           settings-path: ${{ github.workspace }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 17
           cache: maven
       - name: site
         run: ./mvnw --show-version --no-transfer-progress --update-snapshots clean site --file=pom.xml --fail-at-end --batch-mode -Dstyle.color=always  -Ddependency-check.skip=true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 17
           cache: maven
           server-id: ossrh
           settings-path: ${{ github.workspace }}

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=21-tem
+java=17.0.9-tem

--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
 
-        <maven.compiler.testSource>21</maven.compiler.testSource>
-        <maven.compiler.testTarget>21</maven.compiler.testTarget>
+        <maven.compiler.testSource>17</maven.compiler.testSource>
+        <maven.compiler.testTarget>17</maven.compiler.testTarget>
 
         <!-- dependencies and plugins -->
         <jackson-bom.version>2.15.2</jackson-bom.version>
@@ -455,7 +455,7 @@
                     <compilerArgs>
                         <arg>-Xlint:deprecation</arg>
                         <arg>-Xlint:unchecked</arg>
-                        <arg>-proc:full</arg>
+                        <!--<arg>-proc:full</arg>-->
                     </compilerArgs>
                     <source>${java.version}</source>
                     <target>${java.version}</target>


### PR DESCRIPTION
## What's changed?
Revert back to Java 17 instead of Java 21.

## What's your motivation?
Fixes https://github.com/openrewrite/rewrite/issues/3826

## Any additional context
We saw users report failures running on Java 8 due to `MalformedParametersException: Invalid parameter name ""` after switching from https://github.com/openrewrite/rewrite-maven-plugin/compare/v5.14.1...v5.15.0
- https://github.com/openrewrite/rewrite/issues/3826
