### PR TITLE
Deprecate mojo's property "activeRecipes" in favor of "rewrite.activeRecipes"

### DIFF
--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -40,7 +40,11 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
     @Parameter(property = "rewrite.configLocation", alias = "configLocation", defaultValue = "${maven.multiModuleProjectDirectory}/rewrite.yml")
     protected String configLocation;
 
+    /**
+     * @deprecated Use rewrite.activeRecipes instead.
+     */    
     @Parameter(property = "activeRecipes")
+    @Deprecated
     protected List<String> activeRecipes = Collections.emptyList();
 
     @Nullable


### PR DESCRIPTION
Deprecate mojo's property `activeRecipes` as it seems to be replaced by `rewrite.activeRecipes`.

Used in Maven goal `rewrite:run`.

Deprecated arguments can be displayed with help : `mvn org.openrewrite.maven:rewrite-maven-plugin:help -Dgoal=run -Ddetail`