### PR TITLE
Use `kotlinParserBuilder` argument rather than new builder

### DIFF
--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -149,7 +149,7 @@ public class ResourceParser {
         ProtoParser protoParser = new ProtoParser();
         List<Path> protoPaths = new ArrayList<>();
 
-        KotlinParser kotlinParser = KotlinParser.builder().build();
+        KotlinParser kotlinParser = kotlinParserBuilder.build();
         List<Path> kotlinPaths = new ArrayList<>();
 
         GroovyParser groovyParser = GroovyParser.builder().build();


### PR DESCRIPTION
Resolves unused field warning.

Don't think this was intentional; functionally there should be no change as the builders are the same. At most we might see effects of the `.clone()`, which would be good to surface.
https://github.com/openrewrite/rewrite-maven-plugin/blob/ffd2373c8e9b14632473a8aeee5a02cdc0ad4765/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java#L185-L186