### PR TITLE
Adding a logging resolution event listener

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenLoggingResolutionEventListener.java
+++ b/src/main/java/org/openrewrite/maven/MavenLoggingResolutionEventListener.java
@@ -17,39 +17,17 @@ package org.openrewrite.maven;
 
 import org.apache.maven.plugin.logging.Log;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.maven.tree.GroupArtifactVersion;
-import org.openrewrite.maven.tree.ManagedDependency;
-import org.openrewrite.maven.tree.MavenRepository;
-import org.openrewrite.maven.tree.Pom;
-import org.openrewrite.maven.tree.ResolutionEventListener;
-import org.openrewrite.maven.tree.ResolvedDependency;
-import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
-import org.openrewrite.maven.tree.ResolvedPom;
-import org.openrewrite.maven.tree.Scope;
+import org.openrewrite.maven.tree.*;
 
 import java.util.List;
 import java.util.Objects;
 
-public class MavenLoggingResolutionEventListener implements ResolutionEventListener {
+class MavenLoggingResolutionEventListener implements ResolutionEventListener {
 
     private final Log logger;
 
     public MavenLoggingResolutionEventListener(Log logger) {
         this.logger = Objects.requireNonNull(logger, "logger cannot be null");
-    }
-
-    @Override
-    public void downloadMetadata(GroupArtifactVersion gav) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Downloading metadata for " + gav);
-        }
-    }
-
-    @Override
-    public void download(GroupArtifactVersion gav) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Downloading " + gav);
-        }
     }
 
     @Override
@@ -61,52 +39,9 @@ public class MavenLoggingResolutionEventListener implements ResolutionEventListe
 
     @Override
     public void downloadError(GroupArtifactVersion gav, List<String> attemptedUris, @Nullable Pom containing) {
-        StringBuilder sb = new StringBuilder("Failed to download " + gav + pomContaining(containing) + "\n");
-        sb.append("Attempted URIs:").append("\n");
+        StringBuilder sb = new StringBuilder("Failed to download " + gav + pomContaining(containing) + ". Attempted URIs:");
         attemptedUris.forEach(uri -> sb.append("\n  - ").append(uri));
         logger.error(sb);
-    }
-
-    @Override
-    public void parent(Pom parent, Pom containing) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Resolved parent pom " + containing + pomContaining(containing));
-        }
-    }
-
-    @Override
-    public void dependency(Scope scope, ResolvedDependency resolvedDependency, ResolvedPom containing) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Resolved dependency " + resolvedDependency + " with scope " + scope + pomContaining(containing));
-        }
-    }
-
-    @Override
-    public void bomImport(ResolvedGroupArtifactVersion gav, Pom containing) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Resolved imported dependency " + gav + pomContaining(containing));
-        }
-    }
-
-    @Override
-    public void property(String key, String value, Pom containing) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Resolved property \"" + key + "\" with value \"" + value + "\"" + pomContaining(containing));
-        }
-    }
-
-    @Override
-    public void dependencyManagement(ManagedDependency dependencyManagement, Pom containing) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Resolved managed dependency " + dependencyManagement + " on " + pomContaining(containing));
-        }
-    }
-
-    @Override
-    public void repository(MavenRepository mavenRepository, @Nullable ResolvedPom containing) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Resolving maven repository " + mavenRepository + pomContaining(containing));
-        }
     }
 
     @Override
@@ -115,10 +50,10 @@ public class MavenLoggingResolutionEventListener implements ResolutionEventListe
     }
 
     private static String pomContaining(@Nullable Pom containing) {
-        return containing != null ? " on " + containing : "";
+        return containing != null ? " from " + containing.getGav() : "";
     }
 
     private static String pomContaining(@Nullable ResolvedPom containing) {
-        return containing != null ? " on " + containing : "";
+        return containing != null ? " from " + containing.getGav() : "";
     }
 }

--- a/src/main/java/org/openrewrite/maven/MavenLoggingResolutionEventListener.java
+++ b/src/main/java/org/openrewrite/maven/MavenLoggingResolutionEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/maven/MavenLoggingResolutionEventListener.java
+++ b/src/main/java/org/openrewrite/maven/MavenLoggingResolutionEventListener.java
@@ -30,11 +30,11 @@ import org.openrewrite.maven.tree.Scope;
 import java.util.List;
 import java.util.Objects;
 
-public class MavenLoggingResolutionListener implements ResolutionEventListener {
+public class MavenLoggingResolutionEventListener implements ResolutionEventListener {
 
     private final Log logger;
 
-    public MavenLoggingResolutionListener(Log logger) {
+    public MavenLoggingResolutionEventListener(Log logger) {
         this.logger = Objects.requireNonNull(logger, "logger cannot be null");
     }
 

--- a/src/main/java/org/openrewrite/maven/MavenLoggingResolutionListener.java
+++ b/src/main/java/org/openrewrite/maven/MavenLoggingResolutionListener.java
@@ -61,11 +61,10 @@ public class MavenLoggingResolutionListener implements ResolutionEventListener {
 
     @Override
     public void downloadError(GroupArtifactVersion gav, List<String> attemptedUris, @Nullable Pom containing) {
-        if (logger.isInfoEnabled()) {
-            StringBuilder sb = new StringBuilder("Failed to download " + gav + pomContaining(containing));
-            attemptedUris.forEach(uri -> sb.append("\n  - ").append(uri));
-            logger.debug(sb);
-        }
+        StringBuilder sb = new StringBuilder("Failed to download " + gav + pomContaining(containing) + "\n");
+        sb.append("Attempted URIs:").append("\n");
+        attemptedUris.forEach(uri -> sb.append("\n  - ").append(uri));
+        logger.error(sb);
     }
 
     @Override
@@ -112,7 +111,7 @@ public class MavenLoggingResolutionListener implements ResolutionEventListener {
 
     @Override
     public void repositoryAccessFailed(String uri, Throwable e) {
-        logger.info("Failed to access maven repository " + uri, e);
+        logger.error("Failed to access maven repository " + uri, e);
     }
 
     private static String pomContaining(@Nullable Pom containing) {

--- a/src/main/java/org/openrewrite/maven/MavenLoggingResolutionListener.java
+++ b/src/main/java/org/openrewrite/maven/MavenLoggingResolutionListener.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.apache.maven.plugin.logging.Log;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.maven.tree.GroupArtifactVersion;
+import org.openrewrite.maven.tree.ManagedDependency;
+import org.openrewrite.maven.tree.MavenRepository;
+import org.openrewrite.maven.tree.Pom;
+import org.openrewrite.maven.tree.ResolutionEventListener;
+import org.openrewrite.maven.tree.ResolvedDependency;
+import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
+import org.openrewrite.maven.tree.ResolvedPom;
+import org.openrewrite.maven.tree.Scope;
+
+import java.util.List;
+import java.util.Objects;
+
+public class MavenLoggingResolutionListener implements ResolutionEventListener {
+
+    private final Log logger;
+
+    public MavenLoggingResolutionListener(Log logger) {
+        this.logger = Objects.requireNonNull(logger, "logger cannot be null");
+    }
+
+    @Override
+    public void downloadMetadata(GroupArtifactVersion gav) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Downloading metadata for " + gav);
+        }
+    }
+
+    @Override
+    public void download(GroupArtifactVersion gav) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Downloading " + gav);
+        }
+    }
+
+    @Override
+    public void downloadSuccess(ResolvedGroupArtifactVersion gav, @Nullable ResolvedPom containing) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Downloaded " + gav + pomContaining(containing));
+        }
+    }
+
+    @Override
+    public void downloadError(GroupArtifactVersion gav, List<String> attemptedUris, @Nullable Pom containing) {
+        if (logger.isInfoEnabled()) {
+            StringBuilder sb = new StringBuilder("Failed to download " + gav + pomContaining(containing));
+            attemptedUris.forEach(uri -> sb.append("\n  - ").append(uri));
+            logger.debug(sb);
+        }
+    }
+
+    @Override
+    public void parent(Pom parent, Pom containing) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Resolved parent pom " + containing + pomContaining(containing));
+        }
+    }
+
+    @Override
+    public void dependency(Scope scope, ResolvedDependency resolvedDependency, ResolvedPom containing) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Resolved dependency " + resolvedDependency + " with scope " + scope + pomContaining(containing));
+        }
+    }
+
+    @Override
+    public void bomImport(ResolvedGroupArtifactVersion gav, Pom containing) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Resolved imported dependency " + gav + pomContaining(containing));
+        }
+    }
+
+    @Override
+    public void property(String key, String value, Pom containing) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Resolved property \"" + key + "\" with value \"" + value + "\"" + pomContaining(containing));
+        }
+    }
+
+    @Override
+    public void dependencyManagement(ManagedDependency dependencyManagement, Pom containing) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Resolved managed dependency " + dependencyManagement + " on " + pomContaining(containing));
+        }
+    }
+
+    @Override
+    public void repository(MavenRepository mavenRepository, @Nullable ResolvedPom containing) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Resolving maven repository " + mavenRepository + pomContaining(containing));
+        }
+    }
+
+    @Override
+    public void repositoryAccessFailed(String uri, Throwable e) {
+        logger.info("Failed to access maven repository " + uri, e);
+    }
+
+    private static String pomContaining(@Nullable Pom containing) {
+        return containing != null ? " on " + containing : "";
+    }
+
+    private static String pomContaining(@Nullable ResolvedPom containing) {
+        return containing != null ? " on " + containing : "";
+    }
+}

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -465,7 +465,7 @@ public class MavenMojoProjectParser {
         MavenSettings settings = buildSettings();
         MavenExecutionContextView mavenExecutionContext = MavenExecutionContextView.view(ctx);
         mavenExecutionContext.setMavenSettings(settings);
-        mavenExecutionContext.setResolutionListener(new MavenLoggingResolutionListener(logger));
+        mavenExecutionContext.setResolutionListener(new MavenLoggingResolutionEventListener(logger));
 
         if (pomCacheEnabled) {
             //The default pom cache is enabled as a two-layer cache L1 == in-memory and L2 == RocksDb

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -465,6 +465,7 @@ public class MavenMojoProjectParser {
         MavenSettings settings = buildSettings();
         MavenExecutionContextView mavenExecutionContext = MavenExecutionContextView.view(ctx);
         mavenExecutionContext.setMavenSettings(settings);
+        mavenExecutionContext.setResolutionListener(new MavenLoggingResolutionListener(logger));
 
         if (pomCacheEnabled) {
             //The default pom cache is enabled as a two-layer cache L1 == in-memory and L2 == RocksDb


### PR DESCRIPTION
## What's changed?
Added a logging `ResolutionListener` on `MavenMojoProjectParser`.

## What's your motivation?
Identify maven resolution issues (#703).

## Anything in particular you'd like reviewers to focus on?
No

## Anyone you would like to review specifically?
No

## Have you considered any alternatives or workarounds?
Current maven debug output is not helpful regarding the plugin dependency resolution errors.

## Any additional context
No

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
