### PR TITLE
Delaying execution to the end of multi-module project with Maven parallel build

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
@@ -49,12 +49,18 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteMojo {
     public void execute() throws MojoExecutionException {
         if (rewriteSkip) {
             getLog().info("Skipping execution");
+            putState(State.SKIPPED);
             return;
         }
+        putState(State.TO_BE_PROCESSED);
 
         // If the plugin is configured to run over all projects (at the end of the build) only proceed if the plugin
         // is being run on the last project.
-        if (!runPerSubmodule && !isLastProjectInReactor()) {
+        if (!runPerSubmodule && !allProjectsMarked()) {
+            getLog().info("REWRITE: Delaying execution to the end of multi-module project for "
+                + project.getGroupId() + ":"
+                + project.getArtifactId()+ ":"
+                + project.getVersion());
             return;
         }
 
@@ -140,5 +146,6 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteMojo {
         } else {
             getLog().info("Applying recipes would make no changes. No patch file generated.");
         }
+        putState(State.PROCESSED);
     }
 }

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
@@ -40,12 +40,18 @@ public class AbstractRewriteRunMojo extends AbstractRewriteMojo {
     public void execute() throws MojoExecutionException {
         if (rewriteSkip) {
             getLog().info("Skipping execution");
+            putState(State.SKIPPED);
             return;
         }
+        putState(State.TO_BE_PROCESSED);
 
         // If the plugin is configured to run over all projects (at the end of the build) only proceed if the plugin
         // is being run on the last project.
-        if (!runPerSubmodule && !isLastProjectInReactor()) {
+        if (!runPerSubmodule && !allProjectsMarked()) {
+            getLog().info("REWRITE: Delaying execution to the end of multi-module project for "
+                + project.getGroupId() + ":"
+                + project.getArtifactId()+ ":"
+                + project.getVersion());
             return;
         }
 
@@ -150,6 +156,7 @@ public class AbstractRewriteRunMojo extends AbstractRewriteMojo {
                 throw new RuntimeException("Unable to rewrite source files", e);
             }
         }
+        putState(State.PROCESSED);
     }
 
     private static void writeAfter(Path root, Result result, ExecutionContext ctx) {

--- a/src/test/java/org/openrewrite/maven/RewriteRunParallelIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunParallelIT.java
@@ -38,8 +38,6 @@ class RewriteRunParallelIT {
                 .out()
                 .info()
                 .anySatisfy(line -> assertThat(line).contains("Delaying execution to the end of multi-module project for org.openrewrite.maven:b:1.0"));
-                //.filteredOn(line -> line.contains("Delaying execution to the end of multi-module project for org.openrewrite.maven:b:1.0"))
-                //.hasSize(1);
 
         assertThat(result)
                 .isSuccessful()

--- a/src/test/java/org/openrewrite/maven/RewriteRunParallelIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunParallelIT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import com.soebes.itf.jupiter.extension.*;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
+
+@MavenJupiterExtension
+@MavenOption(value = MavenCLIOptions.THREADS, parameter = "2")
+@MavenOption(MavenCLIOptions.NO_TRANSFER_PROGRESS)
+@MavenOption(MavenCLIExtra.MUTE_PLUGIN_VALIDATION_WARNING)
+@DisabledOnOs(OS.WINDOWS)
+@MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:run")
+@SuppressWarnings("NewClassNamingConvention")
+class RewriteRunParallelIT {
+
+    @MavenTest
+    void multi_module_project(MavenExecutionResult result) {
+        assertThat(result)
+                .isSuccessful()
+                .out()
+                .info()
+                .anySatisfy(line -> assertThat(line).contains("Delaying execution to the end of multi-module project for org.openrewrite.maven:b:1.0"));
+                //.filteredOn(line -> line.contains("Delaying execution to the end of multi-module project for org.openrewrite.maven:b:1.0"))
+                //.hasSize(1);
+
+        assertThat(result)
+                .isSuccessful()
+                .out()
+                .warn()
+                .anySatisfy(line -> assertThat(line).contains("org.openrewrite.staticanalysis.SimplifyBooleanExpression"));
+    }
+}

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/a/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/a/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.openrewrite.maven</groupId>
+        <artifactId>multi_module_project</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>a</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>simulate-sleep</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <sleep seconds="10"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/a/src/main/java/sample/MyInterface.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/a/src/main/java/sample/MyInterface.java
@@ -1,0 +1,4 @@
+package sample;
+
+public interface MyInterface {
+}

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/a/src/main/java/sample/SimplifyBooleanSample.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/a/src/main/java/sample/SimplifyBooleanSample.java
@@ -1,0 +1,20 @@
+package sample;
+
+public class SimplifyBooleanSample {
+    boolean ifNoElse() {
+        if (isOddMillis()) {
+            return true;
+        }
+        return false;
+    }
+
+    static boolean isOddMillis() {
+        boolean even = System.currentTimeMillis() % 2 == 0;
+        if (even == true) {
+            return false;
+        }
+        else {
+            return true;
+        }
+    }
+}

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/b/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.openrewrite.maven</groupId>
+        <artifactId>multi_module_project</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>b</artifactId>
+
+</project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/b/src/main/java/sample/EmptyBlockSample.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/b/src/main/java/sample/EmptyBlockSample.java
@@ -1,0 +1,14 @@
+package sample;
+
+import java.util.Random;
+
+public class EmptyBlockSample {
+    int n = sideEffect();
+
+    static {
+    }
+
+    int sideEffect() {
+        return new Random().nextInt();
+    }
+}

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>multi_module_project</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>a</module>
+        <module>b</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>com.example.RewriteRunIT.CodeCleanup</recipe>
+                    </activeRecipes>
+                    <configLocation>
+                        ${maven.multiModuleProjectDirectory}/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/rewrite.yml
+                    </configLocation>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-static-analysis</artifactId>
+                        <version>1.0.4</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/rewrite.yml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/rewrite.yml
@@ -1,0 +1,7 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.example.RewriteRunIT.CodeCleanup
+recipeList:
+  - org.openrewrite.staticanalysis.SimplifyBooleanExpression
+  - org.openrewrite.staticanalysis.SimplifyBooleanReturn
+  - org.openrewrite.staticanalysis.UnnecessaryParentheses


### PR DESCRIPTION
## What's changed?
Since PR #720 merged, I made more tests on different projects, and there is some cases where recipes are still executed before the end of all module packaging when building with Maven parallel build .

I analyzed the implementation of the `installAtEnd` and `deployAtEnd` options of the `maven-install-plugin`:  
https://github.com/apache/maven-install-plugin/blob/master/src/main/java/org/apache/maven/plugins/install/InstallMojo.java  
and `maven-install-plugin` plugins:
https://github.com/apache/maven-deploy-plugin/blob/master/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java

It uses mojo Context to store "state markers", presence of marker means project was "processed".   

This MR is based on this implementation.   

## What's your motivation?
Fix #719

## Anyone you would like to review specifically?
@timtebeek 

## Any additional context
I have added a `RewriteRunParallelIT` test, with a Maven project that have 2 modules `a` and `b`.
These 2 modules are build in parallel (`@MavenOption(value = MavenCLIOptions.THREADS, parameter = "2")`.
And I've added a sleep Antrun task in module `a`, in order to force module `a` finish building after module `b`.`

Without this MR, this test fail, because previous implementation:
`List<MavenProject> sortedProjects = mavenSession.getProjectDependencyGraph().getSortedProjects();`
always return `[a,b]` project list in this order, even if module `a` is longer to build than module `b`.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
