### PR TITLE
Separate JavaVersion markers for src/main and src/test

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -198,12 +198,16 @@ public class MavenMojoProjectParser {
             return sourceFile;
         }).filter(Objects::nonNull);
 
+        // Use runtime Java version for additional resources, as they do not explicitly use a source/target version.
+        List<Marker> additionalResourcesProvenance = new ArrayList<>(projectProvenance);
+        additionalResourcesProvenance.add(getJavaVersionMarker(null, null));
+
         // Collect any additional files that were not parsed above.
         int sourcesParsedBefore = alreadyParsed.size();
         Stream<SourceFile> parsedResourceFiles;
         if (parseAdditionalResources) {
             parsedResourceFiles = rp.parse(mavenProject.getBasedir().toPath(), alreadyParsed)
-                    .map(addProvenance(baseDir, projectProvenance, null));
+                    .map(addProvenance(baseDir, additionalResourcesProvenance, null));
             logDebug(mavenProject, "Parsed " + (alreadyParsed.size() - sourcesParsedBefore) + " additional files found within the project.");
         } else {
             // Only parse Maven wrapper files, such that UpdateMavenWrapper can use the version information.
@@ -213,7 +217,7 @@ public class MavenMojoProjectParser {
                             MavenWrapper.WRAPPER_PROPERTIES_LOCATION,
                             MavenWrapper.WRAPPER_SCRIPT_LOCATION)
                     .flatMap(path -> rp.parse(mavenProject.getBasedir().toPath().resolve(path), alreadyParsed))
-                    .map(addProvenance(baseDir, projectProvenance, null));
+                    .map(addProvenance(baseDir, additionalResourcesProvenance, null));
             logDebug(mavenProject, "Parsed " + (alreadyParsed.size() - sourcesParsedBefore) + " Maven wrapper files found within the project.");
         }
         sourceFiles = Stream.concat(sourceFiles, parsedResourceFiles);
@@ -237,10 +241,22 @@ public class MavenMojoProjectParser {
     }
 
     public List<Marker> generateProvenance(MavenProject mavenProject) {
+        BuildEnvironment buildEnvironment = BuildEnvironment.build(System::getenv);
+        return Stream.of(
+                        buildEnvironment,
+                        gitProvenance(baseDir, buildEnvironment),
+                        OperatingSystemProvenance.current(),
+                        buildTool,
+                        new JavaProject(randomId(), mavenProject.getName(), new JavaProject.Publication(
+                                mavenProject.getGroupId(),
+                                mavenProject.getArtifactId(),
+                                mavenProject.getVersion()
+                        )))
+                .filter(Objects::nonNull)
+                .collect(toList());
+    }
 
-        String javaRuntimeVersion = System.getProperty("java.specification.version");
-        String javaVendor = System.getProperty("java.vm.vendor");
-
+    private static JavaVersion getSrcMainJavaVersion(MavenProject mavenProject) {
         String sourceCompatibility = null;
         String targetCompatibility = null;
 
@@ -280,27 +296,72 @@ public class MavenMojoProjectParser {
             }
         }
 
+        return getJavaVersionMarker(sourceCompatibility, targetCompatibility);
+    }
+
+    private static JavaVersion getSrcTestJavaVersion(MavenProject mavenProject) {
+        String sourceCompatibility = null;
+        String targetCompatibility = null;
+
+        Plugin compilerPlugin = mavenProject.getPlugin("org.apache.maven.plugins:maven-compiler-plugin");
+        if (compilerPlugin != null && compilerPlugin.getConfiguration() instanceof Xpp3Dom) {
+            Xpp3Dom dom = (Xpp3Dom) compilerPlugin.getConfiguration();
+            Xpp3Dom release = dom.getChild("testRelease");
+            if (release != null && StringUtils.isNotEmpty(release.getValue()) && !release.getValue().contains("${")) {
+                sourceCompatibility = release.getValue();
+                targetCompatibility = release.getValue();
+            } else {
+                Xpp3Dom source = dom.getChild("testSource");
+                if (source != null && StringUtils.isNotEmpty(source.getValue()) && !source.getValue().contains("${")) {
+                    sourceCompatibility = source.getValue();
+                }
+                Xpp3Dom target = dom.getChild("testTarget");
+                if (target != null && StringUtils.isNotEmpty(target.getValue()) && !target.getValue().contains("${")) {
+                    targetCompatibility = target.getValue();
+                }
+            }
+        }
+
+        if (sourceCompatibility == null || targetCompatibility == null) {
+            String propertiesReleaseCompatibility = (String) mavenProject.getProperties().get("maven.compiler.testRelease");
+            if (propertiesReleaseCompatibility != null) {
+                sourceCompatibility = propertiesReleaseCompatibility;
+                targetCompatibility = propertiesReleaseCompatibility;
+            } else {
+                String propertiesSourceCompatibility = (String) mavenProject.getProperties().get("maven.compiler.testSource");
+                if (sourceCompatibility == null && propertiesSourceCompatibility != null) {
+                    sourceCompatibility = propertiesSourceCompatibility;
+                }
+                String propertiesTargetCompatibility = (String) mavenProject.getProperties().get("maven.compiler.testTarget");
+                if (targetCompatibility == null && propertiesTargetCompatibility != null) {
+                    targetCompatibility = propertiesTargetCompatibility;
+                }
+            }
+        }
+
+        // Fall back to main source compatibility if test source compatibility is not set, or only partially set.
+        if (sourceCompatibility == null || targetCompatibility == null) {
+            JavaVersion srcMainJavaVersion = getSrcMainJavaVersion(mavenProject);
+            if (sourceCompatibility == null && targetCompatibility == null) {
+                return srcMainJavaVersion;
+            }
+            sourceCompatibility = sourceCompatibility == null ? srcMainJavaVersion.getSourceCompatibility() : sourceCompatibility;
+            targetCompatibility = targetCompatibility == null ? srcMainJavaVersion.getTargetCompatibility() : targetCompatibility;
+        }
+
+        return getJavaVersionMarker(sourceCompatibility, targetCompatibility);
+    }
+
+    private static JavaVersion getJavaVersionMarker(@Nullable String sourceCompatibility, @Nullable String targetCompatibility) {
+        String javaRuntimeVersion = System.getProperty("java.specification.version");
+        String javaVendor = System.getProperty("java.vm.vendor");
         if (sourceCompatibility == null) {
             sourceCompatibility = javaRuntimeVersion;
         }
         if (targetCompatibility == null) {
             targetCompatibility = sourceCompatibility;
         }
-
-        BuildEnvironment buildEnvironment = BuildEnvironment.build(System::getenv);
-        return Stream.of(
-                        buildEnvironment,
-                        gitProvenance(baseDir, buildEnvironment),
-                        OperatingSystemProvenance.current(),
-                        buildTool,
-                        new JavaVersion(randomId(), javaRuntimeVersion, javaVendor, sourceCompatibility, targetCompatibility),
-                        new JavaProject(randomId(), mavenProject.getName(), new JavaProject.Publication(
-                                mavenProject.getGroupId(),
-                                mavenProject.getArtifactId(),
-                                mavenProject.getVersion()
-                        )))
-                .filter(Objects::nonNull)
-                .collect(toList());
+        return new JavaVersion(randomId(), javaRuntimeVersion, javaVendor, sourceCompatibility, targetCompatibility);
     }
 
     private Stream<SourceFile> processMainSources(
@@ -350,6 +411,7 @@ public class MavenMojoProjectParser {
 
         List<Marker> mainProjectProvenance = new ArrayList<>(projectProvenance);
         mainProjectProvenance.add(sourceSet("main", dependencies, typeCache));
+        mainProjectProvenance.add(getSrcMainJavaVersion(mavenProject));
 
         //Filter out any generated source files from the returned list, as we do not want to apply the recipe to the
         //generated files.
@@ -406,6 +468,7 @@ public class MavenMojoProjectParser {
 
         List<Marker> markers = new ArrayList<>(projectProvenance);
         markers.add(sourceSet("test", testDependencies, typeCache));
+        markers.add(getSrcTestJavaVersion(mavenProject));
 
         // Any resources parsed from "test/resources" should also have the test source set added to them.
         int sourcesParsedBefore = alreadyParsed.size();

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -198,16 +198,12 @@ public class MavenMojoProjectParser {
             return sourceFile;
         }).filter(Objects::nonNull);
 
-        // Use runtime Java version for additional resources, as they do not explicitly use a source/target version.
-        List<Marker> additionalResourcesProvenance = new ArrayList<>(projectProvenance);
-        additionalResourcesProvenance.add(getJavaVersionMarker(null, null));
-
         // Collect any additional files that were not parsed above.
         int sourcesParsedBefore = alreadyParsed.size();
         Stream<SourceFile> parsedResourceFiles;
         if (parseAdditionalResources) {
             parsedResourceFiles = rp.parse(mavenProject.getBasedir().toPath(), alreadyParsed)
-                    .map(addProvenance(baseDir, additionalResourcesProvenance, null));
+                    .map(addProvenance(baseDir, projectProvenance, null));
             logDebug(mavenProject, "Parsed " + (alreadyParsed.size() - sourcesParsedBefore) + " additional files found within the project.");
         } else {
             // Only parse Maven wrapper files, such that UpdateMavenWrapper can use the version information.
@@ -217,7 +213,7 @@ public class MavenMojoProjectParser {
                             MavenWrapper.WRAPPER_PROPERTIES_LOCATION,
                             MavenWrapper.WRAPPER_SCRIPT_LOCATION)
                     .flatMap(path -> rp.parse(mavenProject.getBasedir().toPath().resolve(path), alreadyParsed))
-                    .map(addProvenance(baseDir, additionalResourcesProvenance, null));
+                    .map(addProvenance(baseDir, projectProvenance, null));
             logDebug(mavenProject, "Parsed " + (alreadyParsed.size() - sourcesParsedBefore) + " Maven wrapper files found within the project.");
         }
         sourceFiles = Stream.concat(sourceFiles, parsedResourceFiles);

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -299,7 +299,7 @@ public class MavenMojoProjectParser {
         return getJavaVersionMarker(sourceCompatibility, targetCompatibility);
     }
 
-    private static JavaVersion getSrcTestJavaVersion(MavenProject mavenProject) {
+    static JavaVersion getSrcTestJavaVersion(MavenProject mavenProject) {
         String sourceCompatibility = null;
         String targetCompatibility = null;
 

--- a/src/test/java/org/openrewrite/maven/MavenMojoProjectParserTest.java
+++ b/src/test/java/org/openrewrite/maven/MavenMojoProjectParserTest.java
@@ -1,18 +1,10 @@
 package org.openrewrite.maven;
 
-import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.rtinfo.internal.DefaultRuntimeInformation;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.java.marker.JavaVersion;
-import org.openrewrite.marker.Marker;
 
-import java.nio.file.Path;
-import java.util.List;
-
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -21,24 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MavenMojoProjectParserTest {
     @Test
     @DisplayName("Given No Java version information exists in Maven Then java.specification.version should be used")
-    void givenNoJavaVersionInformationExistsInMavenThenJavaSpecificationVersionShouldBeUsed(@TempDir Path dir) {
-        MavenMojoProjectParser sut = new MavenMojoProjectParser(
-                new SystemStreamLog(),
-                dir,
-                false,
-                null,
-                new DefaultRuntimeInformation(),
-                false,
-                emptyList(),
-                emptyList(),
-                -1,
-                null,
-                null,
-                false,
-                true
-        );
-        List<Marker> markers = sut.generateProvenance(new MavenProject());
-        JavaVersion marker = markers.stream().filter(JavaVersion.class::isInstance).map(JavaVersion.class::cast).findFirst().get();
+    void givenNoJavaVersionInformationExistsInMavenThenJavaSpecificationVersionShouldBeUsed() {
+        JavaVersion marker = MavenMojoProjectParser.getSrcTestJavaVersion(new MavenProject());
         assertThat(marker.getSourceCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
         assertThat(marker.getTargetCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
     }


### PR DESCRIPTION
## What's changed?
Create separate JavaVersion markers for src/main and src/test, based on their relative properties.
Fall back to src/main for src/test when not explicitly set.

## What's your motivation?
Allows adopting Java 17 language features in tests when src/main still uses Java 8, as evaluated by HasJavaVersion & UsesJavaVersion.

## Anything in particular you'd like reviewers to focus on?
Files like the Maven wrapper files and other additional resources outside of src/main and src/test now get the runtime Java version marker, as they do not explicitly declare their Java version.

## Have you considered any alternatives or workarounds?
We could continue to assign the wrong src/main JavaVersion to src/test files for projects that use a different version for tests. That might end up surprising folks though, and does not allow some recipes to make changes in src/test when src/main uses a lower version.

## Any additional context
Prompted by a question for a community member/customer.
Would also allow projects to safely adopt Java 17+ features in tests first, before moving to main.