### PR TITLE
Add test for projects having a `module-info.java` file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <developerConnectionUrl>scm:git:ssh://git@github.com/openrewrite/rewrite-maven-plugin.git
         </developerConnectionUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>1.9</java.version>
 
         <maven.compiler.testSource>17</maven.compiler.testSource>
         <maven.compiler.testTarget>17</maven.compiler.testTarget>

--- a/src/test/java/org/openrewrite/maven/RewriteDryRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDryRunIT.java
@@ -37,6 +37,15 @@ class RewriteDryRunIT {
     }
 
     @MavenTest
+    void module_info(MavenExecutionResult result) {
+        assertThat(result)
+                .isSuccessful()
+                .out()
+                .warn()
+                .anySatisfy(line -> assertThat(line).contains("Applying recipes would make no changes."));
+    }
+
+    @MavenTest
     void multi_module_project(MavenExecutionResult result) {
         assertThat(result)
                 .isSuccessful()

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/module_info/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/module_info/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>module_info</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>RewriteDryRunIT#module-info</name>
+
+    <properties>
+        <maven.compiler.source>1.9</maven.compiler.source>
+        <maven.compiler.target>1.9</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.11</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>org.openrewrite.java.search.FindMissingTypes</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/module_info/src/main/java/module-info.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/module_info/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module demo {
+    requires org.slf4j;
+}

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/module_info/src/main/java/sample/UsingLogger.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/module_info/src/main/java/sample/UsingLogger.java
@@ -1,0 +1,7 @@
+package sample;
+
+import org.slf4j.Logger;
+
+public class UsingLogger {
+    private static Logger LOGGER;
+}


### PR DESCRIPTION
It seems that the existence of a `module-info.java` file breaks the determination of types. It is NOT a specific gradle issue, but probably a general issue of the Java parsing framework. This refs https://github.com/openrewrite/rewrite-gradle-plugin/issues/261#issuecomment-1935809117

This PR adds a test case of a project having a `module-info.java` file.

I needed to increase the Java level from 8 to 9 to get it working. I checked `ci.yml`. There, Java 17 is set. Thus, I thought, Java 9 should not be of any issue 😇.

---

## Output with `module-info.java`:

```
[INFO] --- rewrite:5.23.0-SNAPSHOT:dryRun (default-cli) @ module_info ---
[INFO] Using active recipe(s) [org.openrewrite.java.search.FindMissingTypes]
[INFO] Using active styles(s) []
[INFO] Validating active recipes...
[INFO] Project [RewriteDryRunIT#module-info] Resolving Poms...
[INFO] Project [RewriteDryRunIT#module-info] Parsing source files
[INFO] Running recipe(s)...
[WARNING] These recipes would make changes to target\maven-it\org\openrewrite\maven\RewriteDryRunIT\module_info\project\src\main\java\sample\UsingLogger.java:
[WARNING]     org.openrewrite.java.search.FindMissingTypes
[WARNING] Patch file available:
[WARNING]     C:\git-repositories\openrewrite\rewrite-maven-plugin\target\maven-it\org\openrewrite\maven\RewriteDryRunIT\module_info\project\target\rewrite\rewrite.patch
[WARNING] Run 'mvn rewrite:run' to apply the recipes.
```

## Output without `module-info.java`:

```
[INFO] --- rewrite:5.23.0-SNAPSHOT:dryRun (default-cli) @ module_info ---
[INFO] Using active recipe(s) [org.openrewrite.java.search.FindMissingTypes]
[INFO] Using active styles(s) []
[INFO] Validating active recipes...
[INFO] Project [RewriteDryRunIT#module-info] Resolving Poms...
[INFO] Project [RewriteDryRunIT#module-info] Parsing source files
[INFO] Running recipe(s)...
[INFO] Applying recipes would make no changes. No patch file generated.
```