### PR TITLE
Avoid 2 Java level warnings of the compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,11 @@
         <developerConnectionUrl>scm:git:ssh://git@github.com/openrewrite/rewrite-maven-plugin.git
         </developerConnectionUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
 
-        <maven.compiler.testSource>17</maven.compiler.testSource>
-        <maven.compiler.testTarget>17</maven.compiler.testTarget>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+        <!-- a profile in the profiles section sets the maven.compiler.release property on supported JREs -->
+        <maven.compiler.testRelease>17</maven.compiler.testRelease>
 
         <!-- dependencies and plugins -->
         <jackson-bom.version>2.16.1</jackson-bom.version>
@@ -456,17 +457,12 @@
                         <arg>-Xlint:unchecked</arg>
                         <!--<arg>-proc:full</arg>-->
                     </compilerArgs>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.6.3</version>
-                <configuration>
-                    <source>${java.version}</source>
-                </configuration>
                 <executions>
                     <execution>
                         <phase>prepare-package</phase>
@@ -640,6 +636,16 @@
                 <!-- automation via the maven-release-plugin uses a GITHUB_TOKEN which requires 'https' urls for git pushing -->
                 <developerConnectionUrl>scm:git:https://github.com/openrewrite/rewrite-maven-plugin.git
                 </developerConnectionUrl>
+            </properties>
+        </profile>
+        <profile>
+            <!-- set maven.compiler.release on JRE 9+ -->
+            <id>avoid-maven-compiler-warnings</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
The build complains about incomplete Java level settings. Once in the main source compilation ([example from main branch build](https://github.com/openrewrite/rewrite-maven-plugin/actions/runs/8083030796/job/22085154131#step:4:30)), and again in the test source compilation (only if using a JDK > 17). The PR avoids both warnings.

```
[INFO] --- compiler:3.12.1:compile (default-compile) @ rewrite-maven-plugin ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 23 source files with javac [debug target 1.8] to target\classes
[WARNING] bootstrap class path not set in conjunction with -source 8                                      <---------------------
[WARNING] source value 8 is obsolete and will be removed in a future release
[WARNING] target value 8 is obsolete and will be removed in a future release
[WARNING] To suppress warnings about obsolete options, use -Xlint:-options.
[INFO] Annotation processing is enabled because one or more processors were found
...
[INFO] --- compiler:3.12.1:testCompile (default-testCompile) @ rewrite-maven-plugin ---
[INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 10 source files with javac [debug target 17] to target\test-classes
[WARNING] system modules path not set in conjunction with -source 17                                      <---------------------
[INFO] Annotation processing is enabled because one or more processors were found

```

* use only the maven.compiler.x properties
* set release instead of source/target, if possible
* conditionally set release on JDKs >= 9
* remove Javadoc setting (it takes the compiler property as default)

## Anything in particular you'd like reviewers to focus on?
The changes are compatible even with JDK8 because of the profile using the JDK version as activation condition, but the current code doesn't cleanly build *on* JDK8 (with and without my change). If building *on* JDK8 (instead of *for* JDK8) is still a requirement, then that needs to be fixed separately (there are compile errors around the sneakyThrows).

A second thing to look at is the previous use of the system property `java.version`. IMO that's confusing as hell, because every JRE has a built-in system property with the same name. I'd therefore strongly suggest to not re-introduce such a property for any reason.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
