### PR TITLE
Move `getRecipeDescriptor` and add debug log on rewrite.yml path

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -76,8 +76,6 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
     @Component
     protected RepositorySystem repositorySystem;
 
-    private static final String RECIPE_NOT_FOUND_EXCEPTION_MSG = "Could not find recipe '%s' among available recipes";
-
     protected Environment environment() throws MojoExecutionException {
         return environment(getRecipeArtifactCoordinatesClassloader());
     }
@@ -112,6 +110,8 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
 
         if (rewriteConfig.exists()) {
             return new Config(Files.newInputStream(rewriteConfig.toPath()), rewriteConfig.toURI());
+        } else {
+            getLog().debug("No rewrite configuration found at " + absoluteConfigLocation);
         }
 
         return null;
@@ -513,12 +513,5 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
         for (RecipeDescriptor rchild : rd.getRecipeList()) {
             logRecipe(rchild, prefix + "    ");
         }
-    }
-
-    public static RecipeDescriptor getRecipeDescriptor(String recipe, Collection<RecipeDescriptor> recipeDescriptors) throws MojoExecutionException {
-        return recipeDescriptors.stream()
-                .filter(r -> r.getName().equalsIgnoreCase(recipe))
-                .findAny()
-                .orElseThrow(() -> new MojoExecutionException(String.format(RECIPE_NOT_FOUND_EXCEPTION_MSG, recipe)));
     }
 }

--- a/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteDiscoverMojo.java
@@ -97,6 +97,15 @@ public class RewriteDiscoverMojo extends AbstractRewriteMojo {
         }
     }
 
+    private static final String RECIPE_NOT_FOUND_EXCEPTION_MSG = "Could not find recipe '%s' among available recipes";
+
+    private static RecipeDescriptor getRecipeDescriptor(String recipe, Collection<RecipeDescriptor> recipeDescriptors) throws MojoExecutionException {
+        return recipeDescriptors.stream()
+                .filter(r -> r.getName().equalsIgnoreCase(recipe))
+                .findAny()
+                .orElseThrow(() -> new MojoExecutionException(String.format(RECIPE_NOT_FOUND_EXCEPTION_MSG, recipe)));
+    }
+
     private void writeDiscovery(Collection<RecipeDescriptor> availableRecipeDescriptors, Collection<RecipeDescriptor> activeRecipeDescriptors, Collection<NamedStyles> availableStyles) {
         List<RecipeDescriptor> availableRecipesSorted = new ArrayList<>(availableRecipeDescriptors);
         availableRecipesSorted.sort(Comparator.comparing(RecipeDescriptor::getName, String.CASE_INSENSITIVE_ORDER));


### PR DESCRIPTION
https://rewriteoss.slack.com/archives/C01A843MWG5/p1709621242673569

## What's your motivation?
Folks might run in unexpected ways, from different directories or in multi module projects, and similarly place rewrite.yml in unexpected paths. Adding a log line gives us the option to explore what's been evaluated. Additionally moved a method that was exclusively used by `RewriteDiscoverMojo` to that mojo from `AbstractRewriteMojo`.