### PR TITLE
Parse inline checkstyle config from maven-checkstyle-plugin

### DIFF
--- a/src/test/java/org/openrewrite/maven/RewriteRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunIT.java
@@ -50,6 +50,15 @@ class RewriteRunIT {
     }
 
     @MavenTest
+    void checkstyle_inline_rules(MavenExecutionResult result) {
+        assertThat(result)
+                .isSuccessful()
+                .out()
+                .warn()
+                .noneSatisfy(line -> assertThat(line).contains("Unable to parse checkstyle configuration"));
+    }
+
+    @MavenTest
     void recipe_project(MavenExecutionResult result) {
         assertThat(result)
                 .isFailure()

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/checkstyle_inline_rules/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/checkstyle_inline_rules/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.openrewrite.maven</groupId>
+	<artifactId>checkstyle_inline_rules</artifactId>
+	<version>1.0</version>
+	<packaging>jar</packaging>
+	<name>RewriteRunIT#checkstyle_inline_rules</name>
+
+	<properties>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<activeRecipes>
+						<recipe>org.openrewrite.java.format.AutoFormat</recipe>
+					</activeRecipes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.3.1</version>
+				<executions>
+					<execution>
+						<id>verify-style</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<failsOnError>false</failsOnError>
+					<checkstyleRules>
+						<module name="Checker">
+							<module name="FileLength">
+								<property name="max" value="3500" />
+								<property name="fileExtensions" value="java"/>
+							</module>
+							<module name="FileTabCharacter"/>
+							<module name="TreeWalker">
+								<module name="StaticVariableName"/>
+								<module name="TypeName">
+									<property name="format" value="^_?[A-Z][a-zA-Z0-9]*$"/>
+								</module>
+							</module>
+						</module>
+					</checkstyleRules>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/checkstyle_inline_rules/src/main/java/sample/SimplifyBooleanSample.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/checkstyle_inline_rules/src/main/java/sample/SimplifyBooleanSample.java
@@ -1,0 +1,20 @@
+package sample;
+
+public class SimplifyBooleanSample {
+    boolean ifNoElse() {
+        if (isOddMillis()) {
+            return true;
+        }
+        return false;
+    }
+
+    static boolean isOddMillis() {
+        boolean even = System.currentTimeMillis() % 2 == 0;
+        if (even == true) {
+            return false;
+        }
+        else {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Inline checkstyle config from `maven-checkstyle-plugin` can now be parsed, in addition to reading file references from the `configLocation` tag.

## What's your motivation?
Support more of the various config options that exist for `maven-checkstyle-plugin`, to capture more style instructions that exist in existing codebases. 

## Anything in particular you'd like reviewers to focus on?
I didn't think of an obvious positive test case, but I'm happy to take suggestions. For now, just look for the absence of parsing errors.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
