### PR TITLE
Estimate time saved

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
@@ -39,6 +39,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -365,5 +366,20 @@ public abstract class AbstractRewriteBaseRunMojo extends AbstractRewriteMojo {
         for (RecipeDescriptor rchild : rd.getRecipeList()) {
             logRecipe(rchild, prefix + "    ");
         }
+    }
+
+    protected Duration estimateTimeSavedSum(Result result, Duration timeSaving) {
+        if (null != result.getTimeSavings()) {
+            return timeSaving.plus(result.getTimeSavings());
+        }
+        return timeSaving;
+    }
+
+    protected String formatDuration(Duration duration) {
+        return duration.toString()
+                .substring(2)
+                .replaceAll("(\\d[HMS])(?!$)", "$1 ")
+                .toLowerCase()
+                .trim();
     }
 }

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.stream.Stream;
 
 /**
@@ -74,12 +75,14 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteBaseRunMojo {
         }
 
         if (results.isNotEmpty()) {
+            Duration estimateTimeSaved = Duration.ZERO;
             for (Result result : results.generated) {
                 assert result.getAfter() != null;
                 getLog().warn("These recipes would generate a new file " +
                               result.getAfter().getSourcePath() +
                               ":");
                 logRecipesThatMadeChanges(result);
+                estimateTimeSaved = estimateTimeSavedSum(result, estimateTimeSaved);
             }
             for (Result result : results.deleted) {
                 assert result.getBefore() != null;
@@ -87,6 +90,7 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteBaseRunMojo {
                               result.getBefore().getSourcePath() +
                               ":");
                 logRecipesThatMadeChanges(result);
+                estimateTimeSaved = estimateTimeSavedSum(result, estimateTimeSaved);
             }
             for (Result result : results.moved) {
                 assert result.getBefore() != null;
@@ -95,6 +99,7 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteBaseRunMojo {
                               result.getBefore().getSourcePath() + " to " +
                               result.getAfter().getSourcePath() + ":");
                 logRecipesThatMadeChanges(result);
+                estimateTimeSaved = estimateTimeSavedSum(result, estimateTimeSaved);
             }
             for (Result result : results.refactoredInPlace) {
                 assert result.getBefore() != null;
@@ -102,6 +107,7 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteBaseRunMojo {
                               result.getBefore().getSourcePath() +
                               ":");
                 logRecipesThatMadeChanges(result);
+                estimateTimeSaved = estimateTimeSavedSum(result, estimateTimeSaved);
             }
 
             Path outPath;
@@ -138,6 +144,7 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteBaseRunMojo {
             }
             getLog().warn("Patch file available:");
             getLog().warn("    " + patchFile.normalize());
+            getLog().warn("Estimate time saved: " + formatDuration(estimateTimeSaved));
             getLog().warn("Run 'mvn rewrite:run' to apply the recipes.");
 
             if (failOnDryRunResults) {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -190,19 +190,4 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
                 AbstractRewriteMojo.class.getClassLoader()
         );
     }
-
-    protected Duration estimateTimeSavedSum(Result result, Duration timeSaving) {
-        if (null != result.getTimeSavings()) {
-            return timeSaving.plus(result.getTimeSavings());
-        }
-        return timeSaving;
-    }
-
-    protected String formatDuration(Duration duration) {
-        return duration.toString()
-                .substring(2)
-                .replaceAll("(\\d[HMS])(?!$)", "$1 ")
-                .toLowerCase()
-                .trim();
-    }
 }

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -38,6 +38,7 @@ import java.net.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.*;
 
 @SuppressWarnings("NotNullFieldNotInitialized")
@@ -188,5 +189,20 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
                 urls,
                 AbstractRewriteMojo.class.getClassLoader()
         );
+    }
+
+    protected Duration estimateTimeSavedSum(Result result, Duration timeSaving) {
+        if (null != result.getTimeSavings()) {
+            return timeSaving.plus(result.getTimeSavings());
+        }
+        return timeSaving;
+    }
+
+    protected String formatDuration(Duration duration) {
+        return duration.toString()
+                .substring(2)
+                .replaceAll("(\\d[HMS])(?!$)", "$1 ")
+                .toLowerCase()
+                .trim();
     }
 }

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
@@ -30,6 +30,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -67,12 +68,14 @@ public class AbstractRewriteRunMojo extends AbstractRewriteBaseRunMojo {
         }
 
         if (results.isNotEmpty()) {
+            Duration estimateTimeSaved = Duration.ZERO;
             for (Result result : results.generated) {
                 assert result.getAfter() != null;
                 getLog().warn("Generated new file " +
                               result.getAfter().getSourcePath().normalize() +
                               " by:");
                 logRecipesThatMadeChanges(result);
+                estimateTimeSaved = estimateTimeSavedSum(result, estimateTimeSaved);
             }
             for (Result result : results.deleted) {
                 assert result.getBefore() != null;
@@ -80,6 +83,7 @@ public class AbstractRewriteRunMojo extends AbstractRewriteBaseRunMojo {
                               result.getBefore().getSourcePath().normalize() +
                               " by:");
                 logRecipesThatMadeChanges(result);
+                estimateTimeSaved = estimateTimeSavedSum(result, estimateTimeSaved);
             }
             for (Result result : results.moved) {
                 assert result.getAfter() != null;
@@ -88,6 +92,7 @@ public class AbstractRewriteRunMojo extends AbstractRewriteBaseRunMojo {
                               result.getBefore().getSourcePath().normalize() + " to " +
                               result.getAfter().getSourcePath().normalize() + " by:");
                 logRecipesThatMadeChanges(result);
+                estimateTimeSaved = estimateTimeSavedSum(result, estimateTimeSaved);
             }
             for (Result result : results.refactoredInPlace) {
                 assert result.getBefore() != null;
@@ -95,9 +100,11 @@ public class AbstractRewriteRunMojo extends AbstractRewriteBaseRunMojo {
                               result.getBefore().getSourcePath().normalize() +
                               " by:");
                 logRecipesThatMadeChanges(result);
+                estimateTimeSaved = estimateTimeSavedSum(result, estimateTimeSaved);
             }
 
             getLog().warn("Please review and commit the results.");
+            getLog().warn("Estimate time saved: " + formatDuration(estimateTimeSaved));
 
             try {
                 for (Result result : results.generated) {


### PR DESCRIPTION
Fixes #781

## What's changed?

After log changes for each result, sum estimate time saved and log it.

## What's your motivation?

OpenRewrite is working fine and it is very helpful. To show the importance and the time saved, I think it's interesting to show the estimate time saved.

The same was gone for [Gradle plugin ](https://github.com/openrewrite/rewrite-gradle-plugin/pull/294)
