### PR TITLE
Use Maven enforcer for Java and Maven minimum versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,6 +396,29 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.4.1</version>
+                <configuration>
+                    <rules>
+                        <requireJavaVersion>
+                            <version>17</version>
+                        </requireJavaVersion>
+                        <requireMavenVersion>
+                            <version>3.9.6</version>
+                        </requireMavenVersion>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>4.0.0-M14</version>
             </plugin>


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
* Use Maven enforcer to clearly indicate the need for Java 17 during build, as the usage of Java 8 on the classpath may lead to confusion.
* Also enforce the same minimum Maven version as used in the Maven wrapper to ensure both mvn and mvnw create similar output.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
If one tries to build on a JDK less than 17, the error messages are rather confusing (because the maven compiler plugin complains about some unknown symbols only). Make the error more obvious by using Maven enforcer instead.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
