### PR TITLE
Drop deprecated non prefixed properties

### DIFF
--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -54,24 +54,10 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
     @Nullable
     @Parameter(property = "rewrite.activeRecipes")
     protected LinkedHashSet<String> activeRecipes;
-    /**
-     * @deprecated Use {@code rewrite.activeRecipes} instead.
-     */
-    @Nullable
-    @Parameter(property = "activeRecipes")
-    @Deprecated
-    protected LinkedHashSet<String> deprecatedActiveRecipes;
 
     @Nullable
     @Parameter(property = "rewrite.activeStyles")
     protected LinkedHashSet<String> activeStyles;
-    /**
-     * @deprecated Use {@code rewrite.activeStyles} instead.
-     */
-    @Nullable
-    @Parameter(property = "activeStyles")
-    @Deprecated
-    protected LinkedHashSet<String> deprecatedActiveStyles;
 
     @Nullable
     @Parameter(property = "rewrite.metricsUri", alias = "metricsUri")
@@ -113,28 +99,17 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
     @Nullable
     @Parameter(property = "rewrite.exclusions")
     private LinkedHashSet<String> exclusions;
-    /**
-     * @deprecated Use {@code rewrite.exclusions} instead.
-     */
-    @Nullable
-    @Deprecated
-    @Parameter(property = "exclusions")
-    private LinkedHashSet<String> deprecatedExclusions;
 
     protected Set<String> getExclusions() {
-        return getMergedAndCleaned(exclusions, deprecatedExclusions);
+        return getCleanedSet(exclusions);
     }
 
     @Nullable
     @Parameter(property = "rewrite.plainTextMasks")
     private LinkedHashSet<String> plainTextMasks;
-    @Nullable
-    @Parameter(property = "plainTextMasks")
-    @Deprecated
-    private LinkedHashSet<String> deprecatedPlainTextMasks;
 
     protected Set<String> getPlainTextMasks() {
-        Set<String> masks = getMergedAndCleaned(plainTextMasks, deprecatedPlainTextMasks);
+        Set<String> masks = getCleanedSet(plainTextMasks);
         if (!masks.isEmpty()) {
             return masks;
         }
@@ -235,7 +210,7 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
         if (computedRecipes == null) {
             synchronized (this) {
                 if (computedRecipes == null) {
-                    computedRecipes = getMergedAndCleaned(activeRecipes, deprecatedActiveRecipes);
+                    computedRecipes = getCleanedSet(activeRecipes);
                 }
             }
         }
@@ -247,7 +222,7 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
         if (computedStyles == null) {
             synchronized (this) {
                 if (computedStyles == null) {
-                    computedStyles = getMergedAndCleaned(activeStyles, deprecatedActiveStyles);
+                    computedStyles = getCleanedSet(activeStyles);
                 }
             }
         }
@@ -308,7 +283,7 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
         if (computedRecipeArtifactCoordinates == null) {
             synchronized (this) {
                 if (computedRecipeArtifactCoordinates == null) {
-                    computedRecipeArtifactCoordinates = getMergedAndCleaned(recipeArtifactCoordinates, null);
+                    computedRecipeArtifactCoordinates = getCleanedSet(recipeArtifactCoordinates);
                 }
             }
         }
@@ -316,19 +291,15 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
         return computedRecipeArtifactCoordinates;
     }
 
-    private static Set<String> getMergedAndCleaned(@Nullable LinkedHashSet<String> set, @Nullable LinkedHashSet<String> deprecatedSet) {
-        Stream<String> merged = Stream.empty();
-        if (set != null) {
-            merged = set.stream();
+    private static Set<String> getCleanedSet(@Nullable Set<String> set) {
+        if (set == null) {
+            return Collections.emptySet();
         }
-        if (deprecatedSet != null) {
-            merged = Stream.concat(merged, deprecatedSet.stream());
-        }
-        LinkedHashSet<String> collected = merged
+        Set<String> cleaned = set.stream()
                 .filter(Objects::nonNull)
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toCollection(LinkedHashSet::new));
-        return Collections.unmodifiableSet(collected);
+        return Collections.unmodifiableSet(cleaned);
     }
 }

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -112,12 +112,6 @@ public class MavenMojoProjectParser {
     private final boolean runPerSubmodule;
     private final boolean parseAdditionalResources;
 
-    @Deprecated
-    @SuppressWarnings("BooleanParameter")
-    public MavenMojoProjectParser(Log logger, Path baseDir, boolean pomCacheEnabled, @Nullable String pomCacheDirectory, RuntimeInformation runtime, boolean skipMavenParsing, Collection<String> exclusions, Collection<String> plainTextMasks, int sizeThresholdMb, MavenSession session, SettingsDecrypter settingsDecrypter, boolean runPerSubmodule) {
-        this(logger, baseDir, pomCacheEnabled, pomCacheDirectory, runtime, skipMavenParsing, exclusions, plainTextMasks, sizeThresholdMb, session, settingsDecrypter, runPerSubmodule, false);
-    }
-
     @SuppressWarnings("BooleanParameter")
     public MavenMojoProjectParser(Log logger, Path baseDir, boolean pomCacheEnabled, @Nullable String pomCacheDirectory, RuntimeInformation runtime, boolean skipMavenParsing, Collection<String> exclusions, Collection<String> plainTextMasks, int sizeThresholdMb, MavenSession session, SettingsDecrypter settingsDecrypter, boolean runPerSubmodule, boolean parseAdditionalResources) {
         this.logger = logger;


### PR DESCRIPTION
## What's your motivation?
These were added in https://github.com/openrewrite/rewrite-maven-plugin/pull/724 in January, four months ago.
Should have been time enough to clear out their usage, and update the reference documentation:
https://openrewrite.github.io/rewrite-maven-plugin/run-mojo.html

## Any additional context
Would this warrant a major version change? We're at 5.32.1 right now.
Anything else we'd like to include if we are to bump the version number?