### PR TITLE
Add support for artifact recipes as file

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
@@ -85,10 +85,19 @@ public abstract class AbstractRewriteBaseRunMojo extends AbstractRewriteMojo {
             }
 
             URLClassLoader recipeArtifactCoordinatesClassloader = getRecipeArtifactCoordinatesClassloader();
+            URLClassLoader fileRecipeFileClassLoader = getRecipeArtifactFileClassloader();
+            Environment env = null;
             if (recipeArtifactCoordinatesClassloader != null) {
                 merge(getClass().getClassLoader(), recipeArtifactCoordinatesClassloader);
+                env = environment(recipeArtifactCoordinatesClassloader);
             }
-            Environment env = environment(recipeArtifactCoordinatesClassloader);
+            else if (fileRecipeFileClassLoader != null) {
+                merge(getClass().getClassLoader(), fileRecipeFileClassLoader);
+                env = environment(fileRecipeFileClassLoader);
+            }
+            else {
+                env = environment();
+            }
 
             Recipe recipe = env.activateRecipes(getActiveRecipes());
             if (recipe.getRecipeList().isEmpty()) {

--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -199,6 +199,10 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
     private LinkedHashSet<String> recipeArtifactCoordinates;
 
     @Nullable
+    @Parameter(property = "rewrite.recipeArtifactFiles")
+    private LinkedHashSet<String> recipeArtifactFiles;
+
+    @Nullable
     private volatile Set<String> computedRecipes;
 
     @Nullable
@@ -206,6 +210,9 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
 
     @Nullable
     private volatile Set<String> computedRecipeArtifactCoordinates;
+
+    @Nullable
+    private volatile Set<String> computedRecipeArtifactFiles;
 
     protected Set<String> getActiveRecipes() {
         if (computedRecipes == null) {
@@ -290,6 +297,18 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
         }
         //noinspection ConstantConditions
         return computedRecipeArtifactCoordinates;
+    }
+
+    protected Set<String> getRecipeArtifactFiles() {
+        if (computedRecipeArtifactFiles == null) {
+            synchronized (this) {
+                if (computedRecipeArtifactFiles == null) {
+                    computedRecipeArtifactFiles = getCleanedSet(recipeArtifactFiles);
+                }
+            }
+        }
+        //noinspection ConstantConditions
+        return computedRecipeArtifactFiles;
     }
 
     private static Set<String> getCleanedSet(@Nullable Set<String> set) {


### PR DESCRIPTION
Hi,

The plugin already support `recipeArtifactCoordinates` that will resolve artifact from a remote repository and it's transitive dependency. I would like to support loading recipes directly from the file system without having the artifact published to a remote repository.

My use case imply that I don't want to add necessary maven repositories (via pom or settings) So I must resolve recipes locally.

I've just verified that tests are passing, but I didn't add any.

I've tested on a sample project

Right now `recipeArtifactCoordinates`takes precedence on `recipeArtifactFiles`when we can imagine support both by adding more classloader to the environment

```
mvn -Drewrite.activeRecipes=my.test.receipe.TestRecipe -Drewrite.recipeArtifactFiles=myjar.jar org.openrewrite.maven:rewrite-maven-plugin:5.34.0-SNAPSHOT:run
```

## What's changed?

See before

## What's your motivation?

See before

## Anyone you would like to review specifically?

@timtebeek 

## Have you considered any alternatives or workarounds?

Yes by publishing to a remote temporary repository and updating maven repository. But is not convenient on my use case that I don't want to use any custom settings or update poms.

## Any additional context

The GSoC 2024 https://summerofcode.withgoogle.com/programs/2024/projects/anaMmWRR

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
