### PR TITLE
Log stacktrace for repositoryAccessFailed at debug level, not warn

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenLoggingResolutionEventListener.java
+++ b/src/main/java/org/openrewrite/maven/MavenLoggingResolutionEventListener.java
@@ -46,7 +46,8 @@ class MavenLoggingResolutionEventListener implements ResolutionEventListener {
 
     @Override
     public void repositoryAccessFailed(String uri, Throwable e) {
-        logger.warn("Failed to access maven repository " + uri, e);
+        logger.warn("Failed to access maven repository " + uri + " due to: " + e.getMessage());
+        logger.debug(e);
     }
 
     private static String pomContaining(@Nullable Pom containing) {


### PR DESCRIPTION
## What's changed?
Hide stack trace by default, but log it at debug level such that it is accessible when troubleshooting through `-X`.

## What's your motivation?
Folks were alarmed by the full stack trace, incorrectly concluding that recipes aren't running. As per
- https://github.com/openrewrite/rewrite/issues/4101

## Have you considered any alternatives or workarounds?
Will still see if we can not contact failing repositories unnecessarily to really fix openrewrite/rewrite#4101