### PR TITLE
adjusted MavenMojoProjectParser#logParseErrors to also log poms which…

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -236,16 +236,18 @@ public class MavenMojoProjectParser {
     }
 
     private SourceFile logParseErrors(SourceFile source) {
-        if (source instanceof ParseError) {
+        source.getMarkers().findFirst(ParseExceptionResult.class).ifPresent(e -> {
             if (firstWarningLogged.compareAndSet(false, true)) {
                 logger.warn("There were problems parsing some source files" +
                             (mavenSession.getRequest().isShowErrors() ? "" : ", run with --errors to see full stack traces"));
             }
-            logger.warn("There were problems parsing " + source.getSourcePath());
+            String pomMessage = source instanceof Xml.Document
+                    ? "; the pom could not be resolved. Some recipes may not function correctly" : "";
+            logger.warn("There were problems parsing " + source.getSourcePath() + pomMessage);
             if (mavenSession.getRequest().isShowErrors()) {
-                source.getMarkers().findFirst(ParseExceptionResult.class).map(ParseExceptionResult::getMessage).ifPresent(logger::warn);
+                logger.warn(e.getMessage());
             }
-        }
+        });
         return source;
     }
 


### PR DESCRIPTION
… were parsed correctly but encountered an error in resolution

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
see subject

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- https://github.com/openrewrite/rewrite/issues/4353

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
In this implementation, these errors will get logged in the "Parsing source files..." step instead of the "Resolving poms..." step. Logging under the "resolving pom" step might be more intuitive, but this code change is more concise, and, gives an opportunity for the exclude-directory logic to run.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

The message produced for `ParseExceptionResult` for a maven resolution issue is the entire source of the pom, with the relevant error markup comments. This is what will get logged here if `--errors` are enabled, and that's a bit bloated for log output. It might be nice to adjust that logic in `rewrite-maven` to instead produce an abbreviated summary of the problematic file's problems (like how `git diff` just skips to the changed lines, with a few lines of surrounding context)

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
