### PR TITLE
feat: option to add `additionalPlainTextMasks`

### DIFF
--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -38,6 +38,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableSet;
 import static org.openrewrite.java.style.CheckstyleConfigLoader.loadCheckstyleConfig;
 
 @SuppressWarnings("FieldMayBeFinal")
@@ -103,9 +104,21 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
         return getCleanedSet(exclusions);
     }
 
+    /**
+     * Override default plain text masks. If this is specified,
+     * {@code rewrite.additionalPlainTextMasks} will have no effect.
+     */
     @Nullable
     @Parameter(property = "rewrite.plainTextMasks")
     private LinkedHashSet<String> plainTextMasks;
+
+    /**
+     * Allows to add additional plain text masks without overriding
+     * the defaults.
+     */
+    @Nullable
+    @Parameter(property = "rewrite.additionalPlainTextMasks")
+    private LinkedHashSet<String> additionalPlainTextMasks;
 
     protected Set<String> getPlainTextMasks() {
         Set<String> masks = getCleanedSet(plainTextMasks);
@@ -113,7 +126,7 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
             return masks;
         }
         //If not defined, use a default set of masks
-        return new HashSet<>(Arrays.asList(
+        masks = new HashSet<>(Arrays.asList(
                 "**/*.adoc",
                 "**/*.aj",
                 "**/*.bash",
@@ -147,6 +160,8 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
                 "**/*.txt",
                 "**/*.py"
         ));
+        masks.addAll(getCleanedSet(additionalPlainTextMasks));
+        return unmodifiableSet(masks);
     }
 
     @Nullable
@@ -300,6 +315,6 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toCollection(LinkedHashSet::new));
-        return Collections.unmodifiableSet(cleaned);
+        return unmodifiableSet(cleaned);
     }
 }

--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -35,10 +35,10 @@ import java.io.StringWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableSet;
+import static java.util.stream.Collectors.toCollection;
 import static org.openrewrite.java.style.CheckstyleConfigLoader.loadCheckstyleConfig;
 
 @SuppressWarnings("FieldMayBeFinal")
@@ -306,7 +306,7 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
         return computedRecipeArtifactCoordinates;
     }
 
-    private static Set<String> getCleanedSet(@Nullable Set<String> set) {
+    private static Set<String> getCleanedSet(@Nullable Set<@Nullable String> set) {
         if (set == null) {
             return Collections.emptySet();
         }
@@ -314,7 +314,7 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
                 .filter(Objects::nonNull)
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+                .collect(toCollection(LinkedHashSet::new));
         return unmodifiableSet(cleaned);
     }
 }

--- a/src/test/java/org/openrewrite/maven/RewriteRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunIT.java
@@ -109,4 +109,21 @@ class RewriteRunIT {
                 .filteredOn(line -> line.contains("Changes have been made"))
                 .hasSize(1);
     }
+
+    @MavenTest
+    @SystemProperty(value = "rewrite.additionalPlainTextMasks", content = "**/*.ext,**/.in-root")
+    void plaintext_masks(MavenExecutionResult result) {
+        assertThat(result)
+            .isSuccessful()
+            .out()
+            .warn()
+            .contains(
+                "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/src/main/java/sample/in-src.ext by:",
+                "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/.in-root by:",
+                "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/from-default-list.py by:",
+                "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/src/main/java/sample/Dummy.java by:"
+            )
+            .doesNotContain("in-root.ignored");
+    }
+
 }

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/.in-root
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/.in-root
@@ -1,0 +1,1 @@
+shouldBeChanged

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/.in-root
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/.in-root
@@ -1,1 +1,1 @@
-shouldBeChanged
+findMe

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/from-default-list.py
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/from-default-list.py
@@ -1,0 +1,1 @@
+shouldBeChanged

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/from-default-list.py
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/from-default-list.py
@@ -1,1 +1,1 @@
-shouldBeChanged
+findMe

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/in-root.ignored
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/in-root.ignored
@@ -1,0 +1,1 @@
+shouldBeChanged

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/in-root.ignored
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/in-root.ignored
@@ -1,1 +1,1 @@
-shouldBeChanged
+findMe

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/pom.xml
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>org.openrewrite.recipe</groupId>
                         <artifactId>rewrite-static-analysis</artifactId>
-                        <version>1.0.4</version>
+                        <version>1.15.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>single_project</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>RewriteRunIT#plaintext_masks</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>com.example.RewriteRunIT.PlainTextMasks</recipe>
+                    </activeRecipes>
+                    <configLocation>
+                        ${maven.multiModuleProjectDirectory}/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/rewrite.yml
+                    </configLocation>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-static-analysis</artifactId>
+                        <version>1.0.4</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/rewrite.yml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/rewrite.yml
@@ -1,0 +1,9 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.example.RewriteRunIT.PlainTextMasks
+
+recipeList:
+  - org.openrewrite.text.FindAndReplace:
+      find: shouldBeChanged
+      replace: to this
+      regex: false

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/rewrite.yml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/rewrite.yml
@@ -4,6 +4,6 @@ name: com.example.RewriteRunIT.PlainTextMasks
 
 recipeList:
   - org.openrewrite.text.FindAndReplace:
-      find: shouldBeChanged
-      replace: to this
+      find: findMe
+      replace: replacedWith
       regex: false

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/src/main/java/sample/Dummy.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/src/main/java/sample/Dummy.java
@@ -1,0 +1,5 @@
+package sample;
+
+public class Dummy {
+    private static final String shouldBeChanged = "shouldBeChanged";
+}

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/src/main/java/sample/Dummy.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/src/main/java/sample/Dummy.java
@@ -1,5 +1,5 @@
 package sample;
 
 public class Dummy {
-    private static final String shouldBeChanged = "shouldBeChanged";
+    private static final String findMe = "findMe";
 }

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/src/main/java/sample/in-src.ext
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/src/main/java/sample/in-src.ext
@@ -1,0 +1,1 @@
+shouldBeChanged

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/src/main/java/sample/in-src.ext
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/src/main/java/sample/in-src.ext
@@ -1,1 +1,1 @@
-shouldBeChanged
+findMe


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Add `rewrite.additionalPlainTextMasks` plugin option

## What's your motivation?
The default list is super long and it was impossible to extend it - only override, which meant users would need to copy paste it + add their additional masks

