### PR TITLE
Accept any directories under `src` in `ResourceParser`

### DIFF
--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -40,10 +40,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ResourceParser {
+    private static final Set<String> DEFAULT_ACCEPTED_DIRECTORIES = new HashSet<>(Arrays.asList("src"));
     private static final Set<String> DEFAULT_IGNORED_DIRECTORIES = new HashSet<>(Arrays.asList(
             "build", "target", "out",
             ".sonar", ".gradle", ".idea", ".project", "node_modules", ".git", ".metadata", ".DS_Store"));
-    private static final Set<String> DEFAULT_ACCEPTED_DIRECTORIES = new HashSet<>(Arrays.asList("src"));
 
     private final Path baseDir;
     private final Log logger;

--- a/src/main/java/org/openrewrite/maven/ResourceParser.java
+++ b/src/main/java/org/openrewrite/maven/ResourceParser.java
@@ -43,6 +43,7 @@ public class ResourceParser {
     private static final Set<String> DEFAULT_IGNORED_DIRECTORIES = new HashSet<>(Arrays.asList(
             "build", "target", "out",
             ".sonar", ".gradle", ".idea", ".project", "node_modules", ".git", ".metadata", ".DS_Store"));
+    private static final Set<String> DEFAULT_ACCEPTED_DIRECTORIES = new HashSet<>(Arrays.asList("src"));
 
     private final Path baseDir;
     private final Log logger;
@@ -283,6 +284,9 @@ public class ResourceParser {
 
     private boolean isIgnoredDirectory(Path searchDir, Path path) {
         for (Path pathSegment : searchDir.relativize(path)) {
+            if (DEFAULT_ACCEPTED_DIRECTORIES.contains(pathSegment.toString())){
+                return false;
+            }
             if (DEFAULT_IGNORED_DIRECTORIES.contains(pathSegment.toString())) {
                 return true;
             }


### PR DESCRIPTION
Added accepted directories to accept all recursive directories within "src".

## What's changed?
Previously it only checked whether the path contains one of the DEFAULT_IGNORED_DIRECTORIES. 
Now it checks whether the path also contains one of the DEFAULT_ACCEPTED_DIRECTORIES.
Now "src" will return false almost instantly and will not return true although there could be a build or out folder within the "src" folder.

## What's your motivation?
Motivation was the open Issue #850. This is a fix to this issue and maybe a feature to be considered.

- Fixes https://github.com/openrewrite/rewrite-maven-plugin/issues/850
