### PR TITLE
fix: Jelly files should be considered text files.

### DIFF
--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -139,6 +139,7 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
                 "**/*.htm*",
                 "**/gradlew",
                 "**/.java-version",
+                "**/*.jelly",
                 "**/*.jsp",
                 "**/*.ksh",
                 "**/lombok.config",
@@ -156,8 +157,7 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
                 "**/*.svg",
                 "**/*.tsx",
                 "**/*.txt",
-                "**/*.py",
-                "**/*.jelly"
+                "**/*.py"
         ));
         masks.addAll(getCleanedSet(additionalPlainTextMasks));
         return unmodifiableSet(masks);

--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -156,7 +156,8 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
                 "**/*.svg",
                 "**/*.tsx",
                 "**/*.txt",
-                "**/*.py"
+                "**/*.py",
+                "**/*.jelly"
         ));
         masks.addAll(getCleanedSet(additionalPlainTextMasks));
         return unmodifiableSet(masks);


### PR DESCRIPTION
## What's Changed?
I have added a configuration to ensure that Jelly files (with `.jelly` extension) are properly recognized as text files. Currently, `*.jelly` files are treated as quarks (unidentified files).

## Motivation
This change was prompted by the recent release of [the AddJellyXmlDeclaration recipe](https://docs.openrewrite.org/recipes/jenkins/addjellyxmldeclaration). The recipe requires the `additionalPlainTextMasks` option to function correctly. Here's the complete Maven command:

```bash
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
    -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-jenkins:RELEASE \
    -Drewrite.activeRecipes=org.openrewrite.jenkins.AddJellyXmlDeclaration \
    -Drewrite.exportDatatables=true \
    -Drewrite.additionalPlainTextMasks=**/*.jelly
```
As [discussed here](https://github.com/jenkins-infra/plugin-modernizer-tool/pull/355#issuecomment-2485312699), this modification should address the current issue.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
