### PR TITLE
Drop Jackson Kotlin module and dependency management for now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,13 +118,6 @@
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-bom</artifactId>
-                <version>${kotlin.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
                 <groupId>io.rsocket</groupId>
                 <artifactId>rsocket-bom</artifactId>
                 <version>${rsocket.version}</version>
@@ -222,10 +215,6 @@
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-xml</artifactId>
             <version>4.0.4</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
         <dependency>
             <groupId>io.micrometer.prometheus</groupId>


### PR DESCRIPTION
## What's your motivation?
Appeared unused, or at least usage patterns not clear, and lead to having to coordinate version numbers across rewrite-kotlin and here, with [periodic reminders like this one](https://github.com/openrewrite/rewrite-maven-plugin/pull/904).

## Anything in particular you'd like reviewers to focus on?
Any reason this was added before that I might have missed @sambsnyd ?

## Any additional context
Looks to have been added in two parts:
- https://github.com/openrewrite/rewrite-maven-plugin/commit/b7c8126a7327324a9c41a6ef95d8745678790819
- https://github.com/openrewrite/rewrite-maven-plugin/commit/98ea8052bcb678b8c777dada0351450a0c12bb46
