### PR TITLE
Ignore generated pom by maven-shade-plugin and ci-friendly-flatten-maven-plugin

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -646,20 +646,10 @@ public class MavenMojoProjectParser {
 
     private static Path pomPath(MavenProject mavenProject) {
         Path pomPath = mavenProject.getFile().toPath();
-        // org.codehaus.mojo:flatten-maven-plugin produces a synthetic pom unsuitable for our purposes, use the regular pom instead
-        if (pomPath.endsWith(".flattened-pom.xml")) {
-            return mavenProject.getBasedir().toPath().resolve("pom.xml");
-        }
-        // org.apache.maven.plugins:maven-shade-plugin produces a simplified POM for the shaded artifact, use the regular pom instead
-        if (pomPath.endsWith("dependency-reduced-pom.xml")) {
-            return mavenProject.getBasedir().toPath().resolve("pom.xml");
-        }
-        // com.outbrain.swinfra:ci-friendly-flatten-maven-plugin produces a pom unsuitable for our purposes, use the regular pom instead
-        if (pomPath.endsWith(".ci-friendly-pom.xml")) {
-            return mavenProject.getBasedir().toPath().resolve("pom.xml");
-        }
-        // org.eclipse.tycho:tycho-packaging-plugin:update-consumer-pom produces a synthetic pom
-        if (pomPath.endsWith(".tycho-consumer-pom.xml")) {
+        if (pomPath.endsWith(".flattened-pom.xml") ||// org.codehaus.mojo:flatten-maven-plugin
+                pomPath.endsWith("dependency-reduced-pom.xml") || // org.apache.maven.plugins:maven-shade-plugin
+                pomPath.endsWith(".ci-friendly-pom.xml") || // com.outbrain.swinfra:ci-friendly-flatten-maven-plugin
+                pomPath.endsWith(".tycho-consumer-pom.xml")) { // org.eclipse.tycho:tycho-packaging-plugin:update-consumer-pom
             Path normalPom = mavenProject.getBasedir().toPath().resolve("pom.xml");
             // check for the existence of the POM, since Tycho can work pom-less
             if (Files.isReadable(normalPom) && Files.isRegularFile(normalPom)) {

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -650,6 +650,14 @@ public class MavenMojoProjectParser {
         if (pomPath.endsWith(".flattened-pom.xml")) {
             return mavenProject.getBasedir().toPath().resolve("pom.xml");
         }
+        // org.apache.maven.plugins:maven-shade-plugin produces a simplified POM for the shaded artifact, use the regular pom instead
+        if (pomPath.endsWith("dependency-reduced-pom.xml")) {
+            return mavenProject.getBasedir().toPath().resolve("pom.xml");
+        }
+        // com.outbrain.swinfra:ci-friendly-flatten-maven-plugin produces a pom unsuitable for our purposes, use the regular pom instead
+        if (pomPath.endsWith(".ci-friendly-pom.xml")) {
+            return mavenProject.getBasedir().toPath().resolve("pom.xml");
+        }
         // org.eclipse.tycho:tycho-packaging-plugin:update-consumer-pom produces a synthetic pom
         if (pomPath.endsWith(".tycho-consumer-pom.xml")) {
             Path normalPom = mavenProject.getBasedir().toPath().resolve("pom.xml");


### PR DESCRIPTION
- Fix #650 

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Exclude pom generated by org.apache.maven.plugins:maven-shade-plugin and com.outbrain.swinfra:ci-friendly-flatten-maven-plugin

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
