### PR TITLE
Enable Develocity remote build cache on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ on:
   schedule:
     - cron: 0 17 * * *
 
+env:
+  GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.gradle_enterprise_cache_username }}
+  GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.gradle_enterprise_cache_password }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.gradle_enterprise_access_key }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.versionsBackup
 .project
 .settings
 .vscode/
+.mvn/.develocity/

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,45 @@
+<!--
+
+    Copyright 2020 the original author or authors.
+    <p>
+    Licensed under the Moderne Source Available License (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    <p>
+    https://docs.moderne.io/licensing/moderne-source-available-license
+    <p>
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<develocity>
+  <server>
+    <url>https://ge.openrewrite.org/</url>
+    <url>#{env['GRADLE_ENTERPRISE_ACCESS_KEY']}</url>
+  </server>
+  <buildScan>
+    <publishing>
+      <onlyIf><![CDATA[!buildResult.failures.empty]]></onlyIf>
+    </publishing>
+    <capture>
+      <fileFingerprints>true</fileFingerprints>
+    </capture>
+  </buildScan>
+  <buildCache>
+    <local>
+      <storeEnabled>true</storeEnabled>
+    </local>
+    <remote>
+      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+      <server>
+        <credentials>
+          <username>#{env['GRADLE_ENTERPRISE_CACHE_USERNAME']}</username>
+          <password>#{env['GRADLE_ENTERPRISE_CACHE_PASSWORD']}</password>
+        </credentials>
+      </server>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -18,7 +18,6 @@
 <develocity>
   <server>
     <url>https://ge.openrewrite.org/</url>
-    <url>#{env['GRADLE_ENTERPRISE_ACCESS_KEY']}</url>
   </server>
   <buildScan>
     <publishing>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,20 +1,3 @@
-<!--
-
-    Copyright 2020 the original author or authors.
-    <p>
-    Licensed under the Moderne Source Available License (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    <p>
-    https://docs.moderne.io/licensing/moderne-source-available-license
-    <p>
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
 <develocity>
   <server>
     <url>https://ge.openrewrite.org/</url>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,20 +1,3 @@
-<!--
-
-    Copyright 2020 the original author or authors.
-    <p>
-    Licensed under the Moderne Source Available License (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    <p>
-    https://docs.moderne.io/licensing/moderne-source-available-license
-    <p>
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
 <extensions>
   <extension>
     <groupId>com.gradle</groupId>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,24 @@
+<!--
+
+    Copyright 2020 the original author or authors.
+    <p>
+    Licensed under the Moderne Source Available License (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    <p>
+    https://docs.moderne.io/licensing/moderne-source-available-license
+    <p>
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<extensions>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>develocity-maven-extension</artifactId>
+    <version>1.23</version>
+  </extension>
+</extensions>

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,19 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -496,13 +496,15 @@
                         <licenseSet>
                             <header>.mvn/licenseHeader.txt</header>
                             <excludes>
-                                <exclude>pom.xml</exclude>
+                                <exclude>*.xml</exclude>
                                 <exclude>suppressions.xml</exclude>
                                 <exclude>**/README.md</exclude>
                                 <exclude>**/.sdkmanrc</exclude>
                                 <exclude>src/test/resources-its/**</exclude>
                                 <exclude>src/test/resources/**</exclude>
                                 <exclude>src/main/resources/**</exclude>
+                                <exclude>.moderne/</exclude>
+                                <exclude>.mvn/</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>

--- a/pom.xml
+++ b/pom.xml
@@ -430,8 +430,8 @@
                     <compilerArgs>
                         <arg>-Xlint:deprecation</arg>
                         <arg>-Xlint:unchecked</arg>
-                        <!--<arg>-proc:full</arg>-->
                     </compilerArgs>
+                    <proc>none</proc>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/org/openrewrite/maven/BasicIT.java
+++ b/src/test/java/org/openrewrite/maven/BasicIT.java
@@ -27,6 +27,8 @@ import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
 class BasicIT {
 
     @MavenTest
+    @MavenGoal("clean")
+    @MavenGoal("package")
     void groupid_artifactid_should_be_ok(MavenExecutionResult result) {
         assertThat(result)
                 .isSuccessful()
@@ -81,6 +83,7 @@ class BasicIT {
     }
 
     @MavenTest
+    @MavenGoal("clean")
     @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:dryRun")
     void snapshot_ok(MavenExecutionResult result) {
         assertThat(result)

--- a/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
@@ -24,11 +24,11 @@ import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
 @MavenJupiterExtension
 @MavenOption(MavenCLIOptions.NO_TRANSFER_PROGRESS)
 @MavenOption(MavenCLIExtra.MUTE_PLUGIN_VALIDATION_WARNING)
+@MavenGoal("clean")
 @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:discover")
 class RewriteDiscoverIT {
 
     @Nested
-    @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:discover")
     class RecipeLookup {
 
         @MavenTest

--- a/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteDiscoverIT.java
@@ -35,10 +35,10 @@ class RewriteDiscoverIT {
         @SystemProperty(value = "detail", content = "true")
         void rewrite_discover_detail(MavenExecutionResult result) {
             assertThat(result)
-                    .isSuccessful()
-                    .out()
-                    .info()
-                    .anySatisfy(line -> assertThat(line).contains("options"));
+              .isSuccessful()
+              .out()
+              .info()
+              .anySatisfy(line -> assertThat(line).contains("options"));
 
             assertThat(result).out().warn().isEmpty();
         }
@@ -47,20 +47,20 @@ class RewriteDiscoverIT {
         @SystemProperty(value = "recipe", content = "org.openrewrite.JAVA.format.AutoFormAT")
         void rewrite_discover_recipe_lookup_case_insensitive(MavenExecutionResult result) {
             assertThat(result)
-                    .isSuccessful()
-                    .out()
-                    .info()
-                    .anySatisfy(line -> assertThat(line).contains("org.openrewrite.java.format.AutoFormat"));
+              .isSuccessful()
+              .out()
+              .info()
+              .anySatisfy(line -> assertThat(line).contains("org.openrewrite.java.format.AutoFormat"));
         }
 
         @MavenTest
         @SystemProperty(value = "recursion", content = "1")
         void rewrite_discover_recursion(MavenExecutionResult result) {
             assertThat(result)
-                    .isSuccessful()
-                    .out()
-                    .info()
-                    .anySatisfy(line -> assertThat(line).contains("recipeList"));
+              .isSuccessful()
+              .out()
+              .info()
+              .anySatisfy(line -> assertThat(line).contains("recipeList"));
 
             assertThat(result).out().warn().isEmpty();
         }
@@ -69,15 +69,15 @@ class RewriteDiscoverIT {
     @MavenTest
     void rewrite_discover_default(MavenExecutionResult result) {
         assertThat(result)
-                .isSuccessful()
-                .out()
-                .info()
-                .matches(logLines ->
-                        logLines.stream().anyMatch(logLine -> logLine.contains("org.openrewrite.java.format.AutoFormat"))
-                )
-                .matches(logLines ->
-                        logLines.stream().anyMatch(logLine -> logLine.contains("org.openrewrite.java.SpringFormat"))
-                );
+          .isSuccessful()
+          .out()
+          .info()
+          .matches(logLines ->
+            logLines.stream().anyMatch(logLine -> logLine.contains("org.openrewrite.java.format.AutoFormat"))
+          )
+          .matches(logLines ->
+            logLines.stream().anyMatch(logLine -> logLine.contains("org.openrewrite.java.SpringFormat"))
+          );
 
         assertThat(result).out().warn().isEmpty();
     }
@@ -85,10 +85,10 @@ class RewriteDiscoverIT {
     @MavenTest
     void rewrite_discover_rewrite_yml(MavenExecutionResult result) {
         assertThat(result)
-                .isSuccessful()
-                .out()
-                .info()
-                .anySatisfy(line -> assertThat(line).contains("com.example.RewriteDiscoverIT.CodeCleanup"));
+          .isSuccessful()
+          .out()
+          .info()
+          .anySatisfy(line -> assertThat(line).contains("com.example.RewriteDiscoverIT.CodeCleanup"));
 
         assertThat(result).out().warn().isEmpty();
     }
@@ -96,11 +96,10 @@ class RewriteDiscoverIT {
     @MavenTest
     void rewrite_discover_multi_module(MavenExecutionResult result) {
         assertThat(result)
-            .isSuccessful()
-            .out()
-            .info()
-            .anySatisfy(line -> assertThat(line).matches("^a.*SKIPPED$"))
-            .anySatisfy(line -> assertThat(line).matches("^b.*SKIPPED$"));
+          .isSuccessful()
+          .out()
+          .info()
+          .satisfiesOnlyOnce(line -> assertThat(line).contains(":discover"));
 
         assertThat(result).out().warn().isEmpty();
     }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Add configuration for develocity build cache.

## What's your motivation?
Speed up the builds.

## Any additional context
- https://docs.gradle.com/develocity/maven-build-cache/
- https://docs.gradle.com/develocity/maven-get-started/