### PR TITLE
Report first `Throwable` caught in `InMemoryExecutionContext.onError`

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
@@ -47,6 +47,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
@@ -344,7 +345,7 @@ public abstract class AbstractRewriteBaseRunMojo extends AbstractRewriteMojo {
             }
         }
 
-        public @Nullable RuntimeException getFirstException() {
+        public @Nullable RuntimeException getFirstException(AtomicReference<@Nullable Throwable> reference) {
             for (Result result : generated) {
                 for (RuntimeException error : getRecipeErrors(result)) {
                     return error;
@@ -365,7 +366,14 @@ public abstract class AbstractRewriteBaseRunMojo extends AbstractRewriteMojo {
                     return error;
                 }
             }
-            return null;
+            Throwable throwable = reference.get();
+            if (throwable == null) {
+                return null;
+            }
+            if (throwable instanceof RuntimeException) {
+                return (RuntimeException) throwable;
+            }
+            return new RuntimeException(throwable);
         }
 
         private List<RuntimeException> getRecipeErrors(Result result) {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
@@ -47,7 +47,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
@@ -345,7 +344,7 @@ public abstract class AbstractRewriteBaseRunMojo extends AbstractRewriteMojo {
             }
         }
 
-        public @Nullable RuntimeException getFirstException(AtomicReference<@Nullable Throwable> reference) {
+        public @Nullable RuntimeException getFirstException() {
             for (Result result : generated) {
                 for (RuntimeException error : getRecipeErrors(result)) {
                     return error;
@@ -366,14 +365,7 @@ public abstract class AbstractRewriteBaseRunMojo extends AbstractRewriteMojo {
                     return error;
                 }
             }
-            Throwable throwable = reference.get();
-            if (throwable == null) {
-                return null;
-            }
-            if (throwable instanceof RuntimeException) {
-                return (RuntimeException) throwable;
-            }
-            return new RuntimeException(throwable);
+            return null;
         }
 
         private List<RuntimeException> getRecipeErrors(Result result) {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
@@ -79,7 +79,10 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteBaseRunMojo {
             throw firstException;
         }
         if (!throwables.isEmpty()) {
-            getLog().warn("The recipe produced " + throwables.size() + " warning(s). Please report this to the recipe author.", throwables.get(0));
+            getLog().warn("The recipe produced " + throwables.size() + " warning(s). Please report this to the recipe author.");
+            if (!getLog().isDebugEnabled() && !exportDatatables) {
+                getLog().warn("Run with `--debug` or `-Drewrite.exportDatatables=true` to see all warnings.", throwables.get(0));
+            }
         }
 
         if (results.isNotEmpty()) {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
@@ -28,6 +28,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -67,8 +69,8 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteBaseRunMojo {
             return;
         }
 
-        AtomicReference<@Nullable Throwable> throwable = new AtomicReference<>();
-        ExecutionContext ctx = executionContext(throwable);
+        List<Throwable> throwables = new ArrayList<>();
+        ExecutionContext ctx = executionContext(throwables);
 
         ResultsContainer results = listResults(ctx);
 
@@ -77,8 +79,8 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteBaseRunMojo {
             getLog().error("The recipe produced an error. Please report this to the recipe author.");
             throw firstException;
         }
-        if (throwable.get() != null) {
-            getLog().warn("The recipe produced a warning. Please report this to the recipe author.", throwable.get());
+        if (!throwables.isEmpty()) {
+            getLog().warn("The recipe produced " + throwables.size() + " warning(s). Please report this to the recipe author.", throwables.get(0));
         }
 
         if (results.isNotEmpty()) {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
@@ -30,7 +30,6 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 /**

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 /**
@@ -66,10 +67,10 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteBaseRunMojo {
             return;
         }
 
-        ExecutionContext ctx = executionContext();
+        AtomicReference<@Nullable Throwable> throwable = new AtomicReference<>();
+        ExecutionContext ctx = executionContext(throwable);
         ResultsContainer results = listResults(ctx);
-
-        RuntimeException firstException = results.getFirstException();
+        RuntimeException firstException = results.getFirstException(throwable);
         if (firstException != null) {
             getLog().error("The recipe produced an error. Please report this to the recipe author.");
             throw firstException;

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteDryRunMojo.java
@@ -69,11 +69,16 @@ public class AbstractRewriteDryRunMojo extends AbstractRewriteBaseRunMojo {
 
         AtomicReference<@Nullable Throwable> throwable = new AtomicReference<>();
         ExecutionContext ctx = executionContext(throwable);
+
         ResultsContainer results = listResults(ctx);
-        RuntimeException firstException = results.getFirstException(throwable);
+
+        RuntimeException firstException = results.getFirstException();
         if (firstException != null) {
             getLog().error("The recipe produced an error. Please report this to the recipe author.");
             throw firstException;
+        }
+        if (throwable.get() != null) {
+            getLog().warn("The recipe produced a warning. Please report this to the recipe author.", throwable.get());
         }
 
         if (results.isNotEmpty()) {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -126,7 +126,10 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
     }
 
     protected ExecutionContext executionContext(List<Throwable> throwables) {
-        return new InMemoryExecutionContext(throwables::add);
+        return new InMemoryExecutionContext(t -> {
+            getLog().debug(t);
+            throwables.add(t);
+        });
     }
 
     protected Path getBuildRoot() {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -40,7 +40,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 
 @SuppressWarnings("NotNullFieldNotInitialized")
 public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -126,12 +126,8 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
         return env.build();
     }
 
-    protected ExecutionContext executionContext(AtomicReference<@Nullable Throwable> throwable) {
-        return new InMemoryExecutionContext(t -> {
-            if (throwable.get() == null) {
-                throwable.set(t);
-            }
-        });
+    protected ExecutionContext executionContext(List<Throwable> throwables) {
+        return new InMemoryExecutionContext(throwables::add);
     }
 
     protected Path getBuildRoot() {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteMojo.java
@@ -40,6 +40,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 @SuppressWarnings("NotNullFieldNotInitialized")
 public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
@@ -125,8 +126,12 @@ public abstract class AbstractRewriteMojo extends ConfigurableRewriteMojo {
         return env.build();
     }
 
-    protected ExecutionContext executionContext() {
-        return new InMemoryExecutionContext(t -> getLog().debug(t));
+    protected ExecutionContext executionContext(AtomicReference<@Nullable Throwable> throwable) {
+        return new InMemoryExecutionContext(t -> {
+            if (throwable.get() == null) {
+                throwable.set(t);
+            }
+        });
     }
 
     protected Path getBuildRoot() {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Run the configured recipes and apply the changes locally.
@@ -60,9 +61,10 @@ public class AbstractRewriteRunMojo extends AbstractRewriteBaseRunMojo {
             return;
         }
 
-        ExecutionContext ctx = executionContext();
+        AtomicReference<@Nullable Throwable> throwable = new AtomicReference<>();
+        ExecutionContext ctx = executionContext(throwable);
         ResultsContainer results = listResults(ctx);
-        @Nullable RuntimeException firstException = results.getFirstException();
+        RuntimeException firstException = results.getFirstException(throwable);
         if (firstException != null) {
             getLog().error("The recipe produced an error. Please report this to the recipe author.");
             throw firstException;

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
@@ -63,11 +63,16 @@ public class AbstractRewriteRunMojo extends AbstractRewriteBaseRunMojo {
 
         AtomicReference<@Nullable Throwable> throwable = new AtomicReference<>();
         ExecutionContext ctx = executionContext(throwable);
+
         ResultsContainer results = listResults(ctx);
-        RuntimeException firstException = results.getFirstException(throwable);
+
+        RuntimeException firstException = results.getFirstException();
         if (firstException != null) {
             getLog().error("The recipe produced an error. Please report this to the recipe author.");
             throw firstException;
+        }
+        if (throwable.get() != null) {
+            getLog().warn("The recipe produced a warning. Please report this to the recipe author.", throwable.get());
         }
 
         if (results.isNotEmpty()) {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
@@ -33,7 +33,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Run the configured recipes and apply the changes locally.

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
@@ -71,7 +71,10 @@ public class AbstractRewriteRunMojo extends AbstractRewriteBaseRunMojo {
             throw firstException;
         }
         if (!throwables.isEmpty()) {
-            getLog().warn("The recipe produced " + throwables.size() + " warning(s). Please report this to the recipe author.", throwables.get(0));
+            getLog().warn("The recipe produced " + throwables.size() + " warning(s). Please report this to the recipe author.");
+            if (!getLog().isDebugEnabled() && !exportDatatables) {
+                getLog().warn("Run with `--debug` or `-Drewrite.exportDatatables=true` to see all warnings.", throwables.get(0));
+            }
         }
 
         if (results.isNotEmpty()) {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -61,8 +62,8 @@ public class AbstractRewriteRunMojo extends AbstractRewriteBaseRunMojo {
             return;
         }
 
-        AtomicReference<@Nullable Throwable> throwable = new AtomicReference<>();
-        ExecutionContext ctx = executionContext(throwable);
+        List<Throwable> throwables = new ArrayList<>();
+        ExecutionContext ctx = executionContext(throwables);
 
         ResultsContainer results = listResults(ctx);
 
@@ -71,8 +72,8 @@ public class AbstractRewriteRunMojo extends AbstractRewriteBaseRunMojo {
             getLog().error("The recipe produced an error. Please report this to the recipe author.");
             throw firstException;
         }
-        if (throwable.get() != null) {
-            getLog().warn("The recipe produced a warning. Please report this to the recipe author.", throwable.get());
+        if (!throwables.isEmpty()) {
+            getLog().warn("The recipe produced " + throwables.size() + " warning(s). Please report this to the recipe author.", throwables.get(0));
         }
 
         if (results.isNotEmpty()) {

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteRunMojo.java
@@ -17,7 +17,6 @@ package org.openrewrite.maven;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.FileAttributes;
 import org.openrewrite.PrintOutputCapture;


### PR DESCRIPTION
## What's your motivation?
Makes it easier to troubleshoot recipe execution errors that do not result in source related exceptions.

- Fixes https://github.com/openrewrite/rewrite-maven-plugin/issues/940

## Anything in particular you'd like reviewers to focus on?
Now we log a warning for the first caught throwable, but do not halt execution or report subsequent warnings.

## Anyone you would like to review specifically?
@philippe-granet 

## Have you considered any alternatives or workarounds?
We could choose to log warnings beyond the first, or even halt execution. That's a more drastic change though, and perhaps good to first, for a while, raise the visibility of these caught throwables.

## Any additional context
- https://github.com/openrewrite/rewrite-maven-plugin/issues/940#issuecomment-2635127698