### PR TITLE
fix: set TCCL to recipe classloader for SPI resolution

### DIFF
--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Apply OpenRewrite recipes
         run: |
           ./mvnw org.openrewrite.maven:rewrite-maven-plugin:LATEST:run \
-            -Drewrite.activeRecipes=org.openrewrite.recipes.rewrite.OpenRewriteRecipeBestPracticesSubset \
-            -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-static-analysis:RELEASE
+            -Drewrite.activeRecipes=org.openrewrite.recipes.rewrite.OpenRewriteRecipeBestPractices \
+            -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-rewrite:RELEASE
 
       # Capture the diff
       - name: Create patch

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
@@ -240,6 +240,12 @@ public abstract class AbstractRewriteBaseRunMojo extends AbstractRewriteMojo {
 
     protected List<Result> runRecipe(Recipe recipe, LargeSourceSet sourceSet, ExecutionContext ctx) {
         getLog().info("Running recipe(s)...");
+
+        // set the TCCL to the classloader of the recipe to enable class loading via SPI targeting into recipe artifacts
+        // Some Recipe Artifacts define implementations that are resolved by SPI on runtime. These implementations are only
+        // loadable if the TCCL is set to the CL of the Recipes, because that's the only CL that knows them.
+        Thread.currentThread().setContextClassLoader(recipe.getClass().getClassLoader());
+
         RecipeRun recipeRun = recipe.run(sourceSet, ctx);
 
         if (exportDatatables) {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Set TCCL explictely to Recipes CL to be enbale SPI to load classes from within the Recipe Artifact

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
