### PR TITLE
Remove obsoleted `PrometheusRSocketClient`-based `MeterRegistryProvider`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,11 +220,6 @@
             <version>4.0.4</version>
         </dependency>
         <dependency>
-            <groupId>io.micrometer.prometheus</groupId>
-            <artifactId>prometheus-rsocket-client</artifactId>
-            <version>1.5.3</version>
-        </dependency>
-        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <version>1.14.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,7 @@
 
         <!-- dependencies and plugins -->
         <jackson-bom.version>2.17.3</jackson-bom.version>
-        <netty.version>4.1.118.Final</netty.version>
         <rocksdbjni.version>8.8.1</rocksdbjni.version>
-        <rsocket.version>1.1.5</rsocket.version>
         <itf-maven.version>0.13.1</itf-maven.version>
         <maven-dependencies.version>3.9.9</maven-dependencies.version>
         <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
@@ -96,13 +94,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>5.11.4</version>
@@ -113,13 +104,6 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-bom</artifactId>
                 <version>3.27.3</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>io.rsocket</groupId>
-                <artifactId>rsocket-bom</artifactId>
-                <version>${rsocket.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -223,14 +207,6 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <version>1.14.4</version>
-        </dependency>
-        <dependency>
-            <groupId>io.rsocket</groupId>
-            <artifactId>rsocket-transport-netty</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.rsocket</groupId>
-            <artifactId>rsocket-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.rocksdb</groupId>

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
@@ -104,7 +104,7 @@ public abstract class AbstractRewriteBaseRunMojo extends AbstractRewriteMojo {
     }
 
     protected ResultsContainer listResults(ExecutionContext ctx) throws MojoExecutionException, MojoFailureException {
-        try (MeterRegistryProvider meterRegistryProvider = new MeterRegistryProvider(getLog(), metricsUri)) {
+        try (MeterRegistryProvider meterRegistryProvider = new MeterRegistryProvider(getLog(), null)) {
             Metrics.addRegistry(meterRegistryProvider.registry());
 
             Path repositoryRoot = repositoryRoot();

--- a/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
@@ -104,8 +104,7 @@ public abstract class AbstractRewriteBaseRunMojo extends AbstractRewriteMojo {
     }
 
     protected ResultsContainer listResults(ExecutionContext ctx) throws MojoExecutionException, MojoFailureException {
-        try (MeterRegistryProvider meterRegistryProvider = new MeterRegistryProvider(getLog(),
-                metricsUri, metricsUsername, metricsPassword)) {
+        try (MeterRegistryProvider meterRegistryProvider = new MeterRegistryProvider(getLog(), metricsUri)) {
             Metrics.addRegistry(meterRegistryProvider.registry());
 
             Path repositoryRoot = repositoryRoot();

--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -58,18 +58,6 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
     @Parameter(property = "rewrite.activeStyles")
     protected LinkedHashSet<String> activeStyles;
 
-    @Nullable
-    @Parameter(property = "rewrite.metricsUri", alias = "metricsUri")
-    protected String metricsUri;
-
-    @Nullable
-    @Parameter(property = "rewrite.metricsUsername", alias = "metricsUsername")
-    protected String metricsUsername;
-
-    @Nullable
-    @Parameter(property = "rewrite.metricsPassword", alias = "metricsPassword")
-    protected String metricsPassword;
-
     @Parameter(property = "rewrite.pomCacheEnabled", alias = "pomCacheEnabled", defaultValue = "true")
     protected boolean pomCacheEnabled;
 

--- a/src/main/java/org/openrewrite/maven/MeterRegistryProvider.java
+++ b/src/main/java/org/openrewrite/maven/MeterRegistryProvider.java
@@ -24,14 +24,14 @@ public class MeterRegistryProvider implements AutoCloseable {
     private final Log log;
 
     @Nullable
-    private final String uriString;
+    private final String destination;
 
     @Nullable
     private MeterRegistry registry;
 
-    public MeterRegistryProvider(Log log, @Nullable String uriString) {
+    public MeterRegistryProvider(Log log, @Nullable String destination) {
         this.log = log;
-        this.uriString = uriString;
+        this.destination = destination;
     }
 
     public MeterRegistry registry() {
@@ -42,7 +42,7 @@ public class MeterRegistryProvider implements AutoCloseable {
     }
 
     private MeterRegistry buildRegistry() {
-       if ("LOG".equals(uriString)) {
+       if ("LOG".equals(destination)) {
             return new MavenLoggingMeterRegistry(log);
         }
 

--- a/src/main/java/org/openrewrite/maven/MeterRegistryProvider.java
+++ b/src/main/java/org/openrewrite/maven/MeterRegistryProvider.java
@@ -15,25 +15,10 @@
  */
 package org.openrewrite.maven;
 
-import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.micrometer.prometheus.rsocket.PrometheusRSocketClient;
-import io.prometheus.client.CollectorRegistry;
-import io.rsocket.transport.ClientTransport;
-import io.rsocket.transport.netty.client.TcpClientTransport;
-import io.rsocket.transport.netty.client.WebsocketClientTransport;
 import org.apache.maven.plugin.logging.Log;
 import org.jspecify.annotations.Nullable;
-import reactor.netty.http.client.HttpClient;
-import reactor.netty.tcp.TcpClient;
-import reactor.util.retry.Retry;
-
-import java.net.URI;
-import java.time.Duration;
-import java.util.Base64;
 
 public class MeterRegistryProvider implements AutoCloseable {
     private final Log log;
@@ -42,22 +27,11 @@ public class MeterRegistryProvider implements AutoCloseable {
     private final String uriString;
 
     @Nullable
-    private final String username;
-
-    @Nullable
-    private final String password;
-
-    @Nullable
-    private PrometheusRSocketClient metricsClient;
-
-    @Nullable
     private MeterRegistry registry;
 
-    public MeterRegistryProvider(Log log, @Nullable String uriString, @Nullable String username, @Nullable String password) {
+    public MeterRegistryProvider(Log log, @Nullable String uriString) {
         this.log = log;
         this.uriString = uriString;
-        this.username = username;
-        this.password = password;
     }
 
     public MeterRegistry registry() {
@@ -68,73 +42,15 @@ public class MeterRegistryProvider implements AutoCloseable {
     }
 
     private MeterRegistry buildRegistry() {
-        if (uriString == null) {
-            return new CompositeMeterRegistry();
-        } else if ("LOG".equals(uriString)) {
+       if ("LOG".equals(uriString)) {
             return new MavenLoggingMeterRegistry(log);
-        } else {
-            try {
-                URI uri = URI.create(uriString);
-                PrometheusMeterRegistry meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, new CollectorRegistry(), Clock.SYSTEM);
-
-                ClientTransport clientTransport;
-                switch (uri.getScheme()) {
-                    case "ephemeral":
-                    case "https":
-                    case "wss": {
-                        TcpClient tcpClient = TcpClient.create().secure().host(uri.getHost()).port(uri.getPort() == -1 ? 443 : uri.getPort());
-                        clientTransport = getWebsocketClientTransport(tcpClient);
-                        break;
-                    }
-                    case "http":
-                    case "ws": {
-                        TcpClient tcpClient = TcpClient.create().host(uri.getHost()).port(uri.getPort() == -1 ? 80 : uri.getPort());
-                        clientTransport = getWebsocketClientTransport(tcpClient);
-                        break;
-                    }
-                    case "tcp":
-                        clientTransport = TcpClientTransport.create(uri.getHost(), uri.getPort());
-                        break;
-                    default:
-                        log.warn("Unable to publish metrics. Unrecognized scheme " + uri.getScheme());
-                        return new CompositeMeterRegistry();
-                }
-
-                metricsClient = PrometheusRSocketClient
-                        .build(meterRegistry, meterRegistry::scrape, clientTransport)
-                        .retry(Retry.backoff(Long.MAX_VALUE, Duration.ofSeconds(1)).maxBackoff(Duration.ofSeconds(3)))
-                        .connect();
-
-                return meterRegistry;
-            } catch (Throwable t) {
-                log.warn("Unable to publish metrics", t);
-            }
         }
 
         return new CompositeMeterRegistry();
     }
 
-    private ClientTransport getWebsocketClientTransport(TcpClient tcpClient) {
-        //noinspection deprecation
-        HttpClient httpClient = HttpClient.from(tcpClient).wiretap(true);
-        if (username != null && password != null) {
-            httpClient = httpClient.headers(h -> h.add("Authorization", "Basic: " + Base64.getUrlEncoder()
-                    .encodeToString((username + ":" + password).getBytes())));
-        }
-        return WebsocketClientTransport.create(httpClient, "/");
-    }
-
     @Override
     public void close() {
-        if (metricsClient != null) {
-            try {
-                // Don't bother blocking long here. If the build ends before the dying push can happen, so be it.
-                metricsClient.pushAndClose();
-            } catch (Throwable ignore) {
-                // sometimes fails when connection already closed, e.g. due to flaky internet connection
-            }
-        }
-
         if (registry != null) {
             registry.close();
         }

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -2,18 +2,6 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[
-           file name: netty-transport-classes-epoll-4.1.94.Final.jar
-           ]]></notes>
-        <cve>CVE-2023-44487</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-           file name: netty-transport-classes-epoll-4.1.94.Final.jar
-           ]]></notes>
-        <cve>CVE-2023-4586</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
            file name: rewrite-kotlin-1.6.0-SNAPSHOT.jar
            ]]></notes>
         <cve>CVE-2023-30853</cve>
@@ -25,29 +13,5 @@
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
         <cve>CVE-2023-35116</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-            file name: jackson-databind-2.15.2.jar
-            The CVE https://nvd.nist.gov/vuln/detail/CVE-2019-3826 does not actually pertain to the Micrometer Prometheus client, but Prometheus itself
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.micrometer\.prometheus/prometheus\-rsocket\-client@.*$</packageUrl>
-        <cve>CVE-2019-3826</cve>
-    </suppress>
-    <suppress until="2025-02-03Z">
-        <notes><![CDATA[
-        file name: reactor-netty-core-1.0.32.jar
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.projectreactor\.netty/reactor\-netty\-core@.*$</packageUrl>
-        <cve>CVE-2023-34054</cve>
-        <cve>CVE-2023-34062</cve>
-    </suppress>
-    <suppress until="2025-02-03Z">
-        <notes><![CDATA[
-        file name: reactor-netty-http-1.0.32.jar
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.projectreactor\.netty/reactor\-netty\-http@.*$</packageUrl>
-        <cve>CVE-2023-34054</cve>
-        <cve>CVE-2023-34062</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
## What's changed?
- removed consumers of `PrometheusRSocketClient` and related dependencies
- removed plugin properties `rewrite.metricsUri`, `rewrite.metricsUsername` and `rewrite.mertricsPassword`

## What's your motivation?
This dependency is no longer required and indirectly contains a vulnerability from https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java

## Anything in particular you'd like reviewers to focus on?
No

## Anyone you would like to review specifically?
@knutwannheden 

## Have you considered any alternatives or workarounds?
No

## Any additional context
Vulnerable dependency https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java/1.1.10.1

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
