### PR TITLE
Remove gauge warning

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
@@ -105,7 +105,9 @@ public abstract class AbstractRewriteBaseRunMojo extends AbstractRewriteMojo {
 
     protected ResultsContainer listResults(ExecutionContext ctx) throws MojoExecutionException, MojoFailureException {
         try (MeterRegistryProvider meterRegistryProvider = new MeterRegistryProvider(getLog(), null)) {
-            Metrics.addRegistry(meterRegistryProvider.registry());
+            if (!Metrics.globalRegistry.getRegistries().contains(meterRegistryProvider.registry())) {
+                Metrics.addRegistry(meterRegistryProvider.registry());
+            }
 
             Path repositoryRoot = repositoryRoot();
             getLog().info(String.format("Using active recipe(s) %s", getActiveRecipes()));

--- a/src/test/java/org/openrewrite/maven/BasicIT.java
+++ b/src/test/java/org/openrewrite/maven/BasicIT.java
@@ -90,7 +90,6 @@ class BasicIT {
                 .isSuccessful()
                 .out()
                 .warn()
-                .filteredOn(line -> !line.contains("Gauge registration will be ignored"))
                 .isEmpty();
         assertThat(result).out().info().contains("Running recipe(s)...");
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Fix the Gaguge issue that was causing this warning:
```
[WARNING] This Gauge has been already registered (MeterId{name='cache.size', tags=[tag(cache=Maven POMs - default)]}), the Gauge registration will be ignored. Note that subsequent logs will be logged at debug level.
```

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
