### PR TITLE
Also store Charset on `ParsingExecutionContextView`

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -55,6 +55,7 @@ import org.openrewrite.maven.tree.ProfileActivation;
 import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
 import org.openrewrite.maven.utilities.MavenWrapper;
 import org.openrewrite.style.NamedStyles;
+import org.openrewrite.tree.ParsingExecutionContextView;
 import org.openrewrite.xml.tree.Xml;
 
 import java.io.File;
@@ -182,7 +183,10 @@ public class MavenMojoProjectParser {
         JavaParser.Builder<? extends JavaParser, ?> javaParserBuilder = JavaParser.fromJavaVersion()
                 .styles(styles)
                 .logCompilationWarningsAndErrors(false);
-        getCharset(mavenProject).ifPresent(javaParserBuilder::charset);
+        getCharset(mavenProject).ifPresent(charset -> {
+            ParsingExecutionContextView.view(ctx).setCharset(charset);
+            javaParserBuilder.charset(charset);
+        });
 
         // todo, add styles from autoDetect
         KotlinParser.Builder kotlinParserBuilder = KotlinParser.builder();


### PR DESCRIPTION
- Fixes #980

This mimics what we do for the rewrite-gradle-plugin:
https://github.com/openrewrite/rewrite-gradle-plugin/blob/c64b6b61061ef4d01f6fc3a7db723fb4d0c6f0ab/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java#L932

For this then to get picked up in `EncodingDetectingInputStream`
https://github.com/openrewrite/rewrite/blob/49e4463193185c50252e2282f45278fb56e09f56/rewrite-core/src/main/java/org/openrewrite/internal/EncodingDetectingInputStream.java#L27