### PR TITLE
Create type tables for argument GAVs in Maven

### DIFF
--- a/src/main/java/org/openrewrite/maven/RewriteTypeTableMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteTypeTableMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2020 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.eclipse.aether.artifact.Artifact;
 import org.openrewrite.java.internal.parser.TypeTable;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/main/java/org/openrewrite/maven/RewriteTypeTableMojo.java
+++ b/src/main/java/org/openrewrite/maven/RewriteTypeTableMojo.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.eclipse.aether.artifact.Artifact;
+import org.openrewrite.java.internal.parser.TypeTable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Set;
+
+import static java.nio.file.Files.exists;
+
+/**
+ * Create a TypeTable in `src/main/resources/META-INF/rewrite/classpath.tsv.zip` for `rewrite.recipeArtifactCoordinates`.
+ * {@code ./mvnw rewrite:typetable}
+ */
+@Mojo(name = "typetable", requiresDependencyResolution = ResolutionScope.TEST, defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Execute(phase = LifecyclePhase.GENERATE_RESOURCES)
+public class RewriteTypeTableMojo extends AbstractRewriteMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        Set<String> recipeArtifactCoordinates = getRecipeArtifactCoordinates();
+        String srcMainResources = project.getResources().get(0).getDirectory();
+        Path tsvFile = Paths.get(srcMainResources).resolve(TypeTable.DEFAULT_RESOURCE_PATH);
+        Path parentFile = tsvFile.getParent();
+        if (!parentFile.toFile().mkdirs() && !exists(parentFile)) {
+            throw new MojoExecutionException("Unable to create " + parentFile);
+        }
+
+        try (TypeTable.Writer writer = TypeTable.newWriter(Files.newOutputStream(tsvFile))) {
+            for (String recipeArtifactCoordinate : recipeArtifactCoordinates) {
+                // Resolve per GAV, to handle multiple versions of the same artifact
+                for (Artifact artifact : resolveArtifacts(recipeArtifactCoordinate)) {
+                    writer.jar(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion())
+                            .write(artifact.getFile().toPath());
+                    getLog().info(String.format("Wrote %s", artifact));
+                }
+            }
+            getLog().info("Wrote " + project.getBasedir().toPath().relativize(tsvFile));
+
+        } catch (IOException e) {
+            throw new MojoExecutionException("Unable to generate TypeTable", e);
+        }
+    }
+
+    private Set<Artifact> resolveArtifacts(String recipeArtifactCoordinate) throws MojoExecutionException {
+        ArtifactResolver resolver = new ArtifactResolver(repositorySystem, mavenSession);
+        Artifact artifact = resolver.createArtifact(recipeArtifactCoordinate);
+        return resolver.resolveArtifactsAndDependencies(Collections.singleton(artifact));
+    }
+
+}

--- a/src/test/java/org/openrewrite/maven/RewriteTypeTableIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteTypeTableIT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import com.soebes.itf.jupiter.extension.*;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+
+import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
+
+@MavenJupiterExtension
+@MavenOption(MavenCLIOptions.NO_TRANSFER_PROGRESS)
+@MavenOption(MavenCLIExtra.MUTE_PLUGIN_VALIDATION_WARNING)
+@MavenProfile("create-typetable")
+class RewriteTypeTableIT {
+
+    @MavenTest
+    void typetable_default(MavenExecutionResult result) {
+        assertThat(result)
+          .isSuccessful()
+          .project().has("src/main/resources/META-INF/rewrite");
+        assertThat(result).out().info()
+          .matches(logLines -> logLines.stream().anyMatch(line -> line.contains("Wrote com.google.guava:guava:jar:33.3.1-jre")),
+            "contains guava 33.3.1-jre")
+          .matches(logLines -> logLines.stream().anyMatch(line -> line.contains("Wrote com.google.guava:guava:jar:32.0.0-jre")),
+            "contains guava 32.0.0-jre")
+          .matches(logLines -> logLines.stream().anyMatch(line -> line.contains("Wrote src/main/resources/META-INF/rewrite/classpath.tsv.zip")),
+            "write classpath.tsv.zip");
+        assertThat(result).out().error().isEmpty();
+    }
+
+}

--- a/src/test/java/org/openrewrite/maven/RewriteTypeTableIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteTypeTableIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2020 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/b/src/main/java/sample/EmptyBlockSample.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/b/src/main/java/sample/EmptyBlockSample.java
@@ -1,6 +1,7 @@
 package sample;
 
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Random;
 
 public class EmptyBlockSample implements MyInterface {

--- a/src/test/resources-its/org/openrewrite/maven/RewriteTypeTableIT/typetable_default/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteTypeTableIT/typetable_default/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>typetable_default</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>RewriteTypeTableIT#typetable_default</name>
+
+    <profiles>
+        <profile>
+            <id>create-typetable</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>@project.groupId@</groupId>
+                        <artifactId>@project.artifactId@</artifactId>
+                        <version>@project.version@</version>
+                        <configuration>
+                            <recipeArtifactCoordinates>
+                                com.google.guava:guava:33.3.1-jre,
+                                com.google.guava:guava:32.0.0-jre,
+                            </recipeArtifactCoordinates>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>typetable</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>


### PR DESCRIPTION
## What's changed?
Add a new goal to the rewrite-maven-plugin to create type tables.

## What's your motivation?
Parity for folks using Maven, as up to now that had only been [available for Gradle](https://github.com/openrewrite/rewrite-build-gradle-plugin/blob/17964990a5d33cc6c025c315bd87e5eb0e3fd0eb/src/main/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTask.java#L32-L37).

## Anything in particular you'd like reviewers to focus on?
Figured I'd reuse as much as possible, while working around the fact that Maven does not easily allow resolving two versions. By using a profile folks should be able to clearly document the steps to recreate a type table, without it interfering with recipe runs on the same recipe module.

## Anyone you would like to review specifically?
@nmck257 I believe this was relevant for you all there right?

## Have you considered any alternatives or workarounds?
Briefly explored plugin `<dependency>`, but that would not allow for more than one version of an artifact, so figured use `recipeArtifactCoordinates` with GAV arguments instead.

## Any additional context
- https://github.com/openrewrite/rewrite-build-gradle-plugin/pull/75
- https://github.com/openrewrite/rewrite/pull/4932
- https://github.com/openrewrite/rewrite-docs/issues/350