### PR TITLE
Adding example of passing JSON as a `rewrite.options` argument value

### DIFF
--- a/src/test/java/org/openrewrite/maven/RewriteRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunIT.java
@@ -108,7 +108,7 @@ class RewriteRunIT {
 
     @SystemProperties({
       @SystemProperty(value = "rewrite.activeRecipes", content = "org.openrewrite.java.AddCommentToMethod"),
-      @SystemProperty(value = "rewrite.options", content = "comment='{\\\"test\\\":{\\\"some\\\":\\\"yeah\\\"}}',methodPattern=sample.SomeClass doTheThing(..)")
+      @SystemProperty(value = "rewrite.options", content = "comment='{\"test\":{\"some\":\"yeah\"}}',methodPattern=sample.SomeClass doTheThing(..)")
     })
     @MavenTest
     void command_line_options_json(MavenExecutionResult result) {

--- a/src/test/java/org/openrewrite/maven/RewriteRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunIT.java
@@ -18,20 +18,17 @@ package org.openrewrite.maven;
 import com.soebes.itf.jupiter.extension.*;
 import com.soebes.itf.jupiter.maven.MavenExecutionResult;
 import org.junit.jupiter.api.Disabled;
-
-import java.nio.file.FileSystems;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
 
+@DisabledOnOs(OS.WINDOWS)
 @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:run")
 @MavenJupiterExtension
 @MavenOption(MavenCLIOptions.NO_TRANSFER_PROGRESS)
 @MavenOption(MavenCLIExtra.MUTE_PLUGIN_VALIDATION_WARNING)
 class RewriteRunIT {
-    private static String slashForSystem(String outputLine) {
-        String separator = FileSystems.getDefault().getSeparator();
-        return outputLine.replace("/", separator);
-    }
 
     @MavenTest
     void multi_module_project(MavenExecutionResult result) {
@@ -53,8 +50,8 @@ class RewriteRunIT {
           .isSuccessful()
           .out()
           .warn()
-          .contains(slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/multi_source_sets_project/project/src/integration-test/java/sample/IntegrationTest.java by:"))
-          .contains(slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/multi_source_sets_project/project/src/test/java/sample/RegularTest.java by:"));
+          .contains("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/multi_source_sets_project/project/src/integration-test/java/sample/IntegrationTest.java by:")
+          .contains("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/multi_source_sets_project/project/src/test/java/sample/RegularTest.java by:");
     }
 
     @MavenTest
@@ -81,7 +78,7 @@ class RewriteRunIT {
           .isFailure()
           .out()
           .error()
-          .anySatisfy(line -> assertThat(line).contains(slashForSystem("/sample/ThrowingRecipe.java"), "This recipe throws an exception"));
+          .anySatisfy(line -> assertThat(line).contains("/sample/ThrowingRecipe.java", "This recipe throws an exception"));
     }
 
     @MavenTest
@@ -101,7 +98,7 @@ class RewriteRunIT {
     void command_line_options(MavenExecutionResult result) {
         assertThat(result).isSuccessful().out().error().isEmpty();
         assertThat(result).isSuccessful().out().warn()
-          .contains(slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/command_line_options/project/pom.xml by:"))
+          .contains("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/command_line_options/project/pom.xml by:")
           .contains("    org.openrewrite.maven.RemovePlugin: {groupId=org.openrewrite.maven, artifactId=rewrite-maven-plugin}");
         assertThat(result.getMavenProjectResult().getModel().getBuild()).isNull();
     }
@@ -116,7 +113,7 @@ class RewriteRunIT {
           .isSuccessful()
           .out()
           .warn()
-          .contains(slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/command_line_options_json/project/src/main/java/sample/SomeClass.java by:"))
+          .contains("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/command_line_options_json/project/src/main/java/sample/SomeClass.java by:")
           .contains("    org.openrewrite.java.AddCommentToMethod: {comment='{\"test\":{\"some\":\"yeah\"}}', methodPattern=sample.SomeClass doTheThing(..)}");
     }
 
@@ -148,10 +145,10 @@ class RewriteRunIT {
           .out()
           .warn()
           .contains(
-            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/containerfile.build by:"),
-            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/Dockerfile by:"),
-            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/Containerfile by:"),
-            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/build.dockerfile by:")
+            "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/containerfile.build by:",
+            "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/Dockerfile by:",
+            "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/Containerfile by:",
+            "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/build.dockerfile by:"
           );
     }
 
@@ -163,10 +160,10 @@ class RewriteRunIT {
           .out()
           .warn()
           .contains(
-            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/src/main/java/sample/in-src.ext by:"),
-            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/.in-root by:"),
-            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/from-default-list.py by:"),
-            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/src/main/java/sample/Dummy.java by:")
+            "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/src/main/java/sample/in-src.ext by:",
+            "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/.in-root by:",
+            "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/from-default-list.py by:",
+            "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/src/main/java/sample/Dummy.java by:"
           )
           .doesNotContain("in-root.ignored");
     }

--- a/src/test/java/org/openrewrite/maven/RewriteRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunIT.java
@@ -117,7 +117,7 @@ class RewriteRunIT {
           .out()
           .warn()
           .contains(slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/command_line_options_json/project/src/main/java/sample/SomeClass.java by:"))
-          .contains("    org.openrewrite.java.AddCommentToMethod: {comment='{\"test\":{\"some\":\"yeah\"}}', methodPattern=sample.SomeClass doTheThing(..)}");
+          .contains("    org.openrewrite.java.AddCommentToMethod: {comment='{\\\"test\\\":{\\\"some\\\":\\\"yeah\\\"}}', methodPattern=sample.SomeClass doTheThing(..)}");
     }
 
     @Disabled("We should implement a simpler test to make sure that regular markers don't get added to source files")

--- a/src/test/java/org/openrewrite/maven/RewriteRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunIT.java
@@ -18,142 +18,157 @@ package org.openrewrite.maven;
 import com.soebes.itf.jupiter.extension.*;
 import com.soebes.itf.jupiter.maven.MavenExecutionResult;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
+
+import java.nio.file.FileSystems;
 
 import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
 
-@DisabledOnOs(OS.WINDOWS)
 @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:run")
 @MavenJupiterExtension
 @MavenOption(MavenCLIOptions.NO_TRANSFER_PROGRESS)
 @MavenOption(MavenCLIExtra.MUTE_PLUGIN_VALIDATION_WARNING)
 class RewriteRunIT {
+    private static String slashForSystem(String outputLine) {
+        String separator = FileSystems.getDefault().getSeparator();
+        return outputLine.replace("/", separator);
+    }
 
     @MavenTest
     void multi_module_project(MavenExecutionResult result) {
         assertThat(result)
-                .isSuccessful()
-                .out()
-                .warn()
-                .anySatisfy(line -> assertThat(line).contains("org.openrewrite.staticanalysis.SimplifyBooleanExpression"));
+          .isSuccessful()
+          .out()
+          .warn()
+          .anySatisfy(line -> assertThat(line).contains("org.openrewrite.staticanalysis.SimplifyBooleanExpression"));
     }
 
     @MavenGoal("generate-test-sources")
     @MavenTest
     @SystemProperties({
-            @SystemProperty(value = "rewrite.activeRecipes", content = "org.openrewrite.java.search.FindTypes"),
-            @SystemProperty(value = "rewrite.options", content = "fullyQualifiedTypeName=org.junit.jupiter.api.Test")
+      @SystemProperty(value = "rewrite.activeRecipes", content = "org.openrewrite.java.search.FindTypes"),
+      @SystemProperty(value = "rewrite.options", content = "fullyQualifiedTypeName=org.junit.jupiter.api.Test")
     })
     void multi_source_sets_project(MavenExecutionResult result) {
         assertThat(result)
-                .isSuccessful()
-                .out()
-                .warn()
-                .contains(
-                        "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/multi_source_sets_project/project/src/integration-test/java/sample/IntegrationTest.java by:",
-                        "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/multi_source_sets_project/project/src/test/java/sample/RegularTest.java by:"
-                );
+          .isSuccessful()
+          .out()
+          .warn()
+          .contains(slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/multi_source_sets_project/project/src/integration-test/java/sample/IntegrationTest.java by:"))
+          .contains(slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/multi_source_sets_project/project/src/test/java/sample/RegularTest.java by:"));
     }
 
     @MavenTest
     void single_project(MavenExecutionResult result) {
         assertThat(result)
-                .isSuccessful()
-                .out()
-                .warn()
-                .anySatisfy(line -> assertThat(line).contains("org.openrewrite.java.format.AutoFormat"));
+          .isSuccessful()
+          .out()
+          .warn()
+          .anySatisfy(line -> assertThat(line).contains("org.openrewrite.java.format.AutoFormat"));
     }
 
     @MavenTest
     void checkstyle_inline_rules(MavenExecutionResult result) {
         assertThat(result)
-                .isSuccessful()
-                .out()
-                .warn()
-                .noneSatisfy(line -> assertThat(line).contains("Unable to parse checkstyle configuration"));
+          .isSuccessful()
+          .out()
+          .warn()
+          .noneSatisfy(line -> assertThat(line).contains("Unable to parse checkstyle configuration"));
     }
 
     @MavenTest
     void recipe_project(MavenExecutionResult result) {
         assertThat(result)
-                .isFailure()
-                .out()
-                .error()
-                .anySatisfy(line -> assertThat(line).contains("/sample/ThrowingRecipe.java", "This recipe throws an exception"));
+          .isFailure()
+          .out()
+          .error()
+          .anySatisfy(line -> assertThat(line).contains(slashForSystem("/sample/ThrowingRecipe.java"), "This recipe throws an exception"));
     }
 
     @MavenTest
     void cloud_suitability_project(MavenExecutionResult result) {
         assertThat(result)
-                .isSuccessful()
-                .out()
-                .warn()
-                .anySatisfy(line -> assertThat(line).contains("some.jks"));
+          .isSuccessful()
+          .out()
+          .warn()
+          .anySatisfy(line -> assertThat(line).contains("some.jks"));
     }
 
     @MavenTest
     @SystemProperties({
-            @SystemProperty(value = "rewrite.activeRecipes", content = "org.openrewrite.maven.RemovePlugin"),
-            @SystemProperty(value = "rewrite.options", content = "groupId=org.openrewrite.maven,artifactId=rewrite-maven-plugin")
+      @SystemProperty(value = "rewrite.activeRecipes", content = "org.openrewrite.maven.RemovePlugin"),
+      @SystemProperty(value = "rewrite.options", content = "groupId=org.openrewrite.maven,artifactId=rewrite-maven-plugin")
     })
     void command_line_options(MavenExecutionResult result) {
         assertThat(result).isSuccessful().out().error().isEmpty();
         assertThat(result).isSuccessful().out().warn()
-                .contains("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/command_line_options/project/pom.xml by:")
-                .contains("    org.openrewrite.maven.RemovePlugin: {groupId=org.openrewrite.maven, artifactId=rewrite-maven-plugin}");
+          .contains(slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/command_line_options/project/pom.xml by:"))
+          .contains("    org.openrewrite.maven.RemovePlugin: {groupId=org.openrewrite.maven, artifactId=rewrite-maven-plugin}");
         assertThat(result.getMavenProjectResult().getModel().getBuild()).isNull();
+    }
+
+    @SystemProperties({
+      @SystemProperty(value = "rewrite.activeRecipes", content = "org.openrewrite.java.AddCommentToMethod"),
+      @SystemProperty(value = "rewrite.options", content = "comment='{\\\"test\\\":{\\\"some\\\":\\\"yeah\\\"}}',methodPattern=sample.SomeClass doTheThing(..)")
+    })
+    @MavenTest
+    void command_line_options_json(MavenExecutionResult result) {
+        assertThat(result)
+          .isSuccessful()
+          .out()
+          .warn()
+          .contains(slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/command_line_options_json/project/src/main/java/sample/SomeClass.java by:"))
+          .contains("    org.openrewrite.java.AddCommentToMethod: {comment='{\"test\":{\"some\":\"yeah\"}}', methodPattern=sample.SomeClass doTheThing(..)}");
     }
 
     @Disabled("We should implement a simpler test to make sure that regular markers don't get added to source files")
     @MavenTest
     void java_upgrade_project(MavenExecutionResult result) {
         assertThat(result)
-                .isSuccessful()
-                .out()
-                .warn()
-                .filteredOn(line -> line.contains("Changes have been made"))
-                .hasSize(1);
+          .isSuccessful()
+          .out()
+          .warn()
+          .filteredOn(line -> line.contains("Changes have been made"))
+          .hasSize(1);
     }
 
     @MavenTest
     void java_compiler_plugin_project(MavenExecutionResult result) {
         assertThat(result)
-                .isSuccessful()
-                .out()
-                .warn()
-                .filteredOn(line -> line.contains("Changes have been made"))
-                .hasSize(1);
+          .isSuccessful()
+          .out()
+          .warn()
+          .filteredOn(line -> line.contains("Changes have been made"))
+          .hasSize(1);
     }
 
     @MavenTest
     void container_masks(MavenExecutionResult result) {
         assertThat(result)
-                .isSuccessful()
-                .out()
-                .warn()
-                .contains(
-                        "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/containerfile.build by:",
-                        "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/Dockerfile by:",
-                        "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/Containerfile by:",
-                        "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/build.dockerfile by:"
-                );
+          .isSuccessful()
+          .out()
+          .warn()
+          .contains(
+            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/containerfile.build by:"),
+            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/Dockerfile by:"),
+            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/Containerfile by:"),
+            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/container_masks/project/build.dockerfile by:")
+          );
     }
 
     @MavenTest
     @SystemProperty(value = "rewrite.additionalPlainTextMasks", content = "**/*.ext,**/.in-root")
     void plaintext_masks(MavenExecutionResult result) {
         assertThat(result)
-                .isSuccessful()
-                .out()
-                .warn()
-                .contains(
-                        "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/src/main/java/sample/in-src.ext by:",
-                        "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/.in-root by:",
-                        "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/from-default-list.py by:",
-                        "Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/src/main/java/sample/Dummy.java by:"
-                )
-                .doesNotContain("in-root.ignored");
+          .isSuccessful()
+          .out()
+          .warn()
+          .contains(
+            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/src/main/java/sample/in-src.ext by:"),
+            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/.in-root by:"),
+            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/from-default-list.py by:"),
+            slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/plaintext_masks/project/src/main/java/sample/Dummy.java by:")
+          )
+          .doesNotContain("in-root.ignored");
     }
 
 }

--- a/src/test/java/org/openrewrite/maven/RewriteRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunIT.java
@@ -117,7 +117,7 @@ class RewriteRunIT {
           .out()
           .warn()
           .contains(slashForSystem("Changes have been made to target/maven-it/org/openrewrite/maven/RewriteRunIT/command_line_options_json/project/src/main/java/sample/SomeClass.java by:"))
-          .contains("    org.openrewrite.java.AddCommentToMethod: {comment='{\\\"test\\\":{\\\"some\\\":\\\"yeah\\\"}}', methodPattern=sample.SomeClass doTheThing(..)}");
+          .contains("    org.openrewrite.java.AddCommentToMethod: {comment='{\"test\":{\"some\":\"yeah\"}}', methodPattern=sample.SomeClass doTheThing(..)}");
     }
 
     @Disabled("We should implement a simpler test to make sure that regular markers don't get added to source files")

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/command_line_options_json/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/command_line_options_json/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>command_line_options</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>RewriteRunIT#command_line_options_json</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/command_line_options_json/src/main/java/sample/SomeClass.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/command_line_options_json/src/main/java/sample/SomeClass.java
@@ -1,0 +1,5 @@
+package sample;
+
+public class SomeClass {
+    public void doTheThing() {}
+}


### PR DESCRIPTION
### What's changed?
- Added a new example to show an example of passing a JSON string for a `rewrite.options` option.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
