### PR TITLE
Parse makefiles as plain text

### DIFF
--- a/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
+++ b/src/main/java/org/openrewrite/maven/ConfigurableRewriteMojo.java
@@ -136,6 +136,7 @@ public abstract class ConfigurableRewriteMojo extends AbstractMojo {
                 "**/*.ksh",
                 "**/*.lock",
                 "**/lombok.config",
+                "**/[mM]akefile",
                 "**/*.md",
                 "**/*.mf",
                 "**/META-INF/services/**",


### PR DESCRIPTION
## What's changed?
Also parse Makefiles as plain text.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
