### PR TITLE
Add support for multiple main source folders

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -466,16 +466,19 @@ public class MavenMojoProjectParser {
         // Some annotation processors output generated sources to the /target directory. These are added for parsing but
         // should be filtered out of the final SourceFile list.
         List<Path> generatedSourcePaths = listJavaSources(mavenProject.getBasedir().toPath().resolve(mavenProject.getBuild().getDirectory()));
-        String mavenSourceDirectory = mavenProject.getBuild().getSourceDirectory();
-        List<Path> mainJavaSources = Stream.concat(
-                generatedSourcePaths.stream(),
-                listJavaSources(mavenProject.getBasedir().toPath().resolve(mavenSourceDirectory)).stream()
-        ).collect(toList());
+        
+        List<Path> mainJavaSources = new ArrayList<>(generatedSourcePaths);
+        for (String p : mavenProject.getCompileSourceRoots()) {
+            mainJavaSources.addAll(listJavaSources(mavenProject.getBasedir().toPath().resolve(p)));
+        }
 
         alreadyParsed.addAll(mainJavaSources);
 
         // scan Kotlin files
-        List<Path> mainKotlinSources = listKotlinSources(mavenProject, mavenSourceDirectory);
+        List<Path> mainKotlinSources = new ArrayList<>();
+        for (String p : mavenProject.getCompileSourceRoots()) {
+            mainKotlinSources.addAll(listKotlinSources(mavenProject, p));
+        }
         alreadyParsed.addAll(mainKotlinSources);
 
         logInfo(mavenProject, "Parsing source files");

--- a/src/test/java/org/openrewrite/maven/RewriteRunIT.java
+++ b/src/test/java/org/openrewrite/maven/RewriteRunIT.java
@@ -56,6 +56,20 @@ class RewriteRunIT {
           .contains("Changes have been made to project/src/test/java/sample/RegularTest.java by:");
     }
 
+    @MavenGoal("generate-sources")
+    @MavenTest
+    @SystemProperties({
+      @SystemProperty(value = "rewrite.activeRecipes", content = "org.openrewrite.java.format.SingleLineComments"),
+    })
+    void multi_main_source_sets_project(MavenExecutionResult result) {
+        assertThat(result)
+          .isSuccessful()
+          .out()
+          .warn()
+          .contains("Changes have been made to project/src/main/java/sample/MainClass.java by:")
+          .contains("Changes have been made to project/src/additional-main/java/sample/AdditionalMainClass.java by:");
+    }
+
     @MavenTest
     void single_project(MavenExecutionResult result) {
         assertThat(result)

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_main_source_sets_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_main_source_sets_project/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openrewrite.maven</groupId>
+    <artifactId>multi_main_source_sets_project</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>add additional main sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/additional-main/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_main_source_sets_project/src/additional-main/java/sample/AdditionalMainClass.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_main_source_sets_project/src/additional-main/java/sample/AdditionalMainClass.java
@@ -1,0 +1,8 @@
+package sample;
+
+public class AdditionalMainClass {
+    //This is a test class
+    public void method() {
+        System.out.println("Additional main source set");
+    }
+}

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_main_source_sets_project/src/main/java/sample/MainClass.java
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_main_source_sets_project/src/main/java/sample/MainClass.java
@@ -1,0 +1,8 @@
+package sample;
+
+public class MainClass {
+    //This is a test class
+    public void method() {
+        System.out.println("Main source set");
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds support for multiple main source folders, mirroring the functionality added for test source folders in PR #888.

## Motivation
Maven projects using `build-helper-maven-plugin` or similar tools to configure additional source directories (e.g., for generated code, integration modules, or multi-source projects) need the rewrite-maven-plugin to process all configured main source directories, not just the default `src/main/java`.

## Changes
- Modified `MavenMojoProjectParser.processMainSources()` to iterate through all compile source roots using `mavenProject.getCompileSourceRoots()` instead of only processing the single default source directory
- Updated both Java and Kotlin source collection to handle multiple source directories
- Added integration test `multi_main_source_sets_project` to verify recipes are applied to files in all configured main source directories

## Testing
- Added new integration test that configures an additional main source directory using `build-helper-maven-plugin`
- Test verifies that the `SingleLineComments` recipe is applied to Java files in both:
  - `src/main/java`
  - `src/additional-main/java`
- All existing tests pass

## Related
- Follows the same implementation pattern as PR #888 which added support for multiple test source folders
- Resolves the need for symmetric functionality between main and test source processing

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>