### PR TITLE
Include active profiles from external parent poms

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -619,6 +619,7 @@ public class MavenMojoProjectParser {
         mavenParserBuilder.property("basedir", topLevelProject.getBasedir().getAbsoluteFile().getParent());
         mavenParserBuilder.property("project.basedir", topLevelProject.getBasedir().getAbsoluteFile().getParent());
         topLevelProject.getActiveProfiles().forEach(it -> mavenParserBuilder.activeProfiles(it.getId()));
+        topLevelProject.getInjectedProfileIds().forEach((gav, profiles) -> mavenParserBuilder.activeProfiles(profiles.toArray(new String[0])));
         mavenSession.getRequest().getActiveProfiles().forEach(mavenParserBuilder::activeProfiles);
         mavenSession.getUserProperties().forEach((key, value) ->
                 mavenParserBuilder.property((String) key, (String) value));


### PR DESCRIPTION
## What's changed?
Include active profiles from external parent POMs.

## What's your motivation?
- https://github.com/openrewrite/rewrite/pull/6526

When dependencies are defined in a conditional profile of an external parent, we weren't taking note of conditional profile activations. In such cases, it would appear as if the profile was not enabled and thus those dependencies would appear as included by Maven proper, but excluded by OpenRewrite.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
@sambsnyd 

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
The logic isn't exactly correct, but it's close enough. In the context of the Maven execution, the profile will only be active in the specific parent POM where it is activated. Unfortunately, we don't keep track of the entire resolved POM graph for all contributors, so as a consequence we can't attach it to only that specific external parent POM instance.

Due to the resolution logic within `MavenParser` all `activeProfiles` are considered equal by ID throughout the Maven POM graph, but Maven does not treat profiles in this way. However, fixing that correctly would have very deep, very widespread impact throughout a large chunk of OpenRewrite's Maven code.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
