### PR TITLE
Parse src/main/webapp resources for WAR projects

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -504,6 +504,17 @@ public class MavenMojoProjectParser {
             }
         }
 
+        // Also parse webapp resources (e.g., web.xml) for WAR projects
+        if ("war".equals(mavenProject.getPackaging())) {
+            Path webappPath = mavenProject.getBasedir().toPath().resolve("src/main/webapp");
+            if (Files.exists(webappPath) && !alreadyParsed.contains(webappPath)) {
+                List<Path> accepted = omniParser.acceptedPaths(baseDir, webappPath);
+                alreadyParsed.add(webappPath);
+                sourceFiles = Stream.concat(sourceFiles, omniParser.parse(accepted, baseDir, ctx));
+                alreadyParsed.addAll(accepted);
+            }
+        }
+
         List<Marker> mainProjectProvenance = new ArrayList<>();
         mainProjectProvenance.add(JavaSourceSet.build("main", dependencies));
         mainProjectProvenance.add(getSrcMainJavaVersion(mavenProject));


### PR DESCRIPTION
## Summary

- Add parsing of `src/main/webapp` directory for projects with WAR packaging
- Files in webapp directory now receive the `JavaProject` marker from the project's provenance

## Problem

When building LSTs for Maven WAR projects, files in `src/main/webapp` (like `web.xml`) were not receiving the `JavaProject` marker. This caused recipes like `WebXmlToWebApplicationInitializer` to skip these files because they check for `JavaProject` to determine the target project context.

The root cause: `MavenMojoProjectParser` only parsed resources from `mavenProject.getResources()` (standard Maven resource directories like `src/main/resources`), but `src/main/webapp` is not a standard Maven resource directory - it's a special directory for WAR packaging.

## Solution

After parsing standard Maven resources, check if the project has WAR packaging. If so, also parse `src/main/webapp` using the same `OmniParser`. These files then receive the correct `JavaProject` marker when provenance is applied.

```java
// Also parse webapp resources (e.g., web.xml) for WAR projects
if ("war".equals(mavenProject.getPackaging())) {
    Path webappPath = mavenProject.getBasedir().toPath().resolve("src/main/webapp");
    if (Files.exists(webappPath) && !alreadyParsed.contains(webappPath)) {
        List<Path> accepted = omniParser.acceptedPaths(baseDir, webappPath);
        alreadyParsed.add(webappPath);
        sourceFiles = Stream.concat(sourceFiles, omniParser.parse(accepted, baseDir, ctx));
        alreadyParsed.addAll(accepted);
    }
}
```

## Test plan

- [x] Existing tests pass
- [ ] Manual testing with WAR project containing web.xml

- Fixes moderneinc/customer-requests#1760