### PR TITLE
Add Slack notification for scheduled CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,14 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
           SONATYPE_SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+      - name: slack-notification
+        if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+          MSG_MINIMAL: true
+          SLACK_MESSAGE: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_USERNAME: ${{ github.repository }} CI failure
+          SLACK_COLOR: failure
+          SLACK_FOOTER: ''


### PR DESCRIPTION
## Summary
- Add Slack failure notification step to the CI workflow, matching the pattern used by other openrewrite repos through the reusable Gradle CI workflow
- Only triggers on scheduled (cron) build failures to avoid noise from PR/push builds
- Uses the same `rtCamp/action-slack-notify` action and `OPS_GITHUB_ACTIONS_WEBHOOK` secret already in use org-wide