### PR TITLE
Validate DEVELOCITY_ACCESS_KEY format before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
           server-password: SONATYPE_PASSWORD
           gpg-private-key: ${{ secrets.OSSRH_SIGNING_KEY }}
           gpg-passphrase: SONATYPE_SIGNING_PASSWORD
+      - name: validate-develocity-access-key
+        run: |
+          if [ -n "$DEVELOCITY_ACCESS_KEY" ] && ! echo "$DEVELOCITY_ACCESS_KEY" | grep -q '='; then
+            echo "DEVELOCITY_ACCESS_KEY is malformed (missing server-host= prefix), unsetting"
+            echo "DEVELOCITY_ACCESS_KEY=" >> $GITHUB_ENV
+          fi
       - name: build
         run: ./mvnw --show-version --no-transfer-progress --update-snapshots clean verify --file=pom.xml --fail-at-end --batch-mode -Dstyle.color=always
       - name: publish-snapshots


### PR DESCRIPTION
## Summary

The Develocity Maven extension requires `DEVELOCITY_ACCESS_KEY` in the format `server-host=access-key`, but the `gradle_enterprise_access_key` secret appears to be malformed (missing the server host prefix). This causes the extension to crash after every Maven invocation, failing both the outer build and all integration tests.

This adds a validation step that unsets the env var if it doesn't contain `=`, allowing CI to pass until the secret is corrected.

## Test plan
- [ ] Verify CI passes on this branch
- [ ] Update the `gradle_enterprise_access_key` secret to the correct `server-host=access-key` format for a permanent fix