### PR TITLE
Skip parsing generated sources; use compiled classes instead

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -238,14 +238,15 @@ public class MavenMojoProjectParser {
         Collection<PathMatcher> exclusionMatchers = exclusions.stream()
                 .map(pattern -> baseDir.getFileSystem().getPathMatcher("glob:" + pattern))
                 .collect(toList());
+        Path buildDirectory = baseDir.relativize(Paths.get(mavenProject.getBuild().getDirectory()));
         sourceFiles = sourceFiles.map(sourceFile -> {
-            if (isExcluded(repository, exclusionMatchers, sourceFile.getSourcePath())) {
+            if (isExcluded(repository, exclusionMatchers, buildDirectory, sourceFile.getSourcePath())) {
                 return null;
             }
             return sourceFile;
         }).filter(Objects::nonNull);
 
-        Stream<SourceFile> mavenWrapperFiles = parseMavenWrapperFiles(mavenProject, exclusionMatchers, parsedPaths, ctx);
+        Stream<SourceFile> mavenWrapperFiles = parseMavenWrapperFiles(mavenProject, exclusionMatchers, buildDirectory, parsedPaths, ctx);
         sourceFiles = Stream.concat(sourceFiles, mavenWrapperFiles);
 
         Stream<SourceFile> nonProjectResources = parseNonProjectResources(mavenProject, parsedPaths, ctx);
@@ -256,7 +257,10 @@ public class MavenMojoProjectParser {
                 .map(this::logParseErrors);
     }
 
-    static boolean isExcluded(org.openrewrite.jgit.lib.@Nullable Repository repository, Collection<PathMatcher> exclusionMatchers, Path path) {
+    static boolean isExcluded(org.openrewrite.jgit.lib.@Nullable Repository repository, Collection<PathMatcher> exclusionMatchers, Path buildDirectory, Path path) {
+        if (path.startsWith(buildDirectory)) {
+            return true;
+        }
         for (PathMatcher excluded : exclusionMatchers) {
             if (excluded.matches(path)) {
                 return true;
@@ -559,11 +563,7 @@ public class MavenMojoProjectParser {
         mainProjectProvenance.add(JavaSourceSet.build("main", dependencies));
         mainProjectProvenance.add(getSrcMainJavaVersion(mavenProject));
 
-        //Filter out any generated source files from the returned list, as we do not want to apply the recipe to the
-        //generated files.
-        Path buildDirectory = baseDir.relativize(Paths.get(mavenProject.getBuild().getDirectory()));
         return sourceFiles
-                .filter(s -> !s.getSourcePath().startsWith(buildDirectory))
                 .map(addProvenance(mainProjectProvenance));
     }
 
@@ -644,11 +644,7 @@ public class MavenMojoProjectParser {
         testProjectProvenance.add(JavaSourceSet.build("test", testDependencies));
         testProjectProvenance.add(getSrcTestJavaVersion(mavenProject));
 
-        //Filter out any generated source files from the returned list, as we do not want to apply the recipe to the
-        //generated files.
-        Path buildDirectory = baseDir.relativize(Paths.get(mavenProject.getBuild().getDirectory()));
         return sourceFiles
-                .filter(s -> !s.getSourcePath().startsWith(buildDirectory))
                 .map(addProvenance(testProjectProvenance));
     }
 
@@ -1090,7 +1086,7 @@ public class MavenMojoProjectParser {
         }
     }
 
-    private Stream<SourceFile> parseMavenWrapperFiles(MavenProject mavenProject, Collection<PathMatcher> exclusions, Set<Path> parsedPaths, ExecutionContext ctx) {
+    private Stream<SourceFile> parseMavenWrapperFiles(MavenProject mavenProject, Collection<PathMatcher> exclusions, Path buildDirectory, Set<Path> parsedPaths, ExecutionContext ctx) {
         Stream<SourceFile> sourceFiles = Stream.empty();
         if (mavenProject.getParent() == null) {
             OmniParser omniParser = omniParser(parsedPaths, mavenProject);
@@ -1103,7 +1099,7 @@ public class MavenMojoProjectParser {
                             MavenWrapper.WRAPPER_SCRIPT_LOCATION)
                     .map(Path::toAbsolutePath)
                     .filter(Files::exists)
-                    .filter(it -> !isExcluded(repository, exclusions, it))
+                    .filter(it -> !isExcluded(repository, exclusions, buildDirectory, it))
                     .filter(omniParser::accept)
                     .collect(toList());
             sourceFiles = omniParser.parse(mavenWrapperFiles, baseDir, ctx);

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -240,13 +240,13 @@ public class MavenMojoProjectParser {
                 .collect(toList());
         Path buildDirectory = baseDir.relativize(Paths.get(mavenProject.getBuild().getDirectory()));
         sourceFiles = sourceFiles.map(sourceFile -> {
-            if (isExcluded(repository, exclusionMatchers, buildDirectory, sourceFile.getSourcePath())) {
+            if (sourceFile.getSourcePath().startsWith(buildDirectory) || isExcluded(repository, exclusionMatchers, sourceFile.getSourcePath())) {
                 return null;
             }
             return sourceFile;
         }).filter(Objects::nonNull);
 
-        Stream<SourceFile> mavenWrapperFiles = parseMavenWrapperFiles(mavenProject, exclusionMatchers, buildDirectory, parsedPaths, ctx);
+        Stream<SourceFile> mavenWrapperFiles = parseMavenWrapperFiles(mavenProject, exclusionMatchers, parsedPaths, ctx);
         sourceFiles = Stream.concat(sourceFiles, mavenWrapperFiles);
 
         Stream<SourceFile> nonProjectResources = parseNonProjectResources(mavenProject, parsedPaths, ctx);
@@ -257,10 +257,7 @@ public class MavenMojoProjectParser {
                 .map(this::logParseErrors);
     }
 
-    static boolean isExcluded(org.openrewrite.jgit.lib.@Nullable Repository repository, Collection<PathMatcher> exclusionMatchers, Path buildDirectory, Path path) {
-        if (path.startsWith(buildDirectory)) {
-            return true;
-        }
+    static boolean isExcluded(org.openrewrite.jgit.lib.@Nullable Repository repository, Collection<PathMatcher> exclusionMatchers, Path path) {
         for (PathMatcher excluded : exclusionMatchers) {
             if (excluded.matches(path)) {
                 return true;
@@ -1086,7 +1083,7 @@ public class MavenMojoProjectParser {
         }
     }
 
-    private Stream<SourceFile> parseMavenWrapperFiles(MavenProject mavenProject, Collection<PathMatcher> exclusions, Path buildDirectory, Set<Path> parsedPaths, ExecutionContext ctx) {
+    private Stream<SourceFile> parseMavenWrapperFiles(MavenProject mavenProject, Collection<PathMatcher> exclusions, Set<Path> parsedPaths, ExecutionContext ctx) {
         Stream<SourceFile> sourceFiles = Stream.empty();
         if (mavenProject.getParent() == null) {
             OmniParser omniParser = omniParser(parsedPaths, mavenProject);
@@ -1099,7 +1096,7 @@ public class MavenMojoProjectParser {
                             MavenWrapper.WRAPPER_SCRIPT_LOCATION)
                     .map(Path::toAbsolutePath)
                     .filter(Files::exists)
-                    .filter(it -> !isExcluded(repository, exclusions, buildDirectory, it))
+                    .filter(it -> !isExcluded(repository, exclusions, it))
                     .filter(omniParser::accept)
                     .collect(toList());
             sourceFiles = omniParser.parse(mavenWrapperFiles, baseDir, ctx);

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -220,16 +220,14 @@ public class MavenMojoProjectParser {
         KotlinParser.Builder kotlinParserBuilder = KotlinParser.builder();
         GroovyParser.Builder groovyParserBuilder = GroovyParser.builder();
 
-        // Pre-populate parsedPaths with all source paths from both scopes
-        // to prevent resource parsers from claiming cross-scope sources as PlainText
-        List<String> mainSourceRoots = filterGeneratedSourceRoots(mavenProject, mavenProject.getExecutionProject().getCompileSourceRoots());
-        List<String> testSourceRoots = filterGeneratedSourceRoots(mavenProject, mavenProject.getExecutionProject().getTestCompileSourceRoots());
-        parsedPaths.addAll(listJavaSources(mavenProject, mainSourceRoots));
+        // Pre-populate parsedPaths with all source paths from both scopes (including generated sources)
+        // to prevent resource parsers from claiming these as PlainText
+        parsedPaths.addAll(listJavaSources(mavenProject, mavenProject.getExecutionProject().getCompileSourceRoots()));
         parsedPaths.addAll(listKotlinSources(mavenProject, "compile", mavenProject.getBuild().getSourceDirectory()));
-        parsedPaths.addAll(listGroovySources(mavenProject, mainSourceRoots));
-        parsedPaths.addAll(listJavaSources(mavenProject, testSourceRoots));
+        parsedPaths.addAll(listGroovySources(mavenProject, mavenProject.getExecutionProject().getCompileSourceRoots()));
+        parsedPaths.addAll(listJavaSources(mavenProject, mavenProject.getExecutionProject().getTestCompileSourceRoots()));
         parsedPaths.addAll(listKotlinSources(mavenProject, "test-compile", mavenProject.getBuild().getTestSourceDirectory()));
-        parsedPaths.addAll(listGroovySources(mavenProject, testSourceRoots));
+        parsedPaths.addAll(listGroovySources(mavenProject, mavenProject.getExecutionProject().getTestCompileSourceRoots()));
 
         if (scopes.contains(MAIN)) {
             sourceFiles = Stream.concat(sourceFiles, processMainSources(mavenProject, javaParserBuilder.clone(), kotlinParserBuilder.clone(), groovyParserBuilder.clone(), parsedPaths, ctx));

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -239,12 +239,8 @@ public class MavenMojoProjectParser {
                 .map(pattern -> baseDir.getFileSystem().getPathMatcher("glob:" + pattern))
                 .collect(toList());
         Path buildDirectory = baseDir.relativize(Paths.get(mavenProject.getBuild().getDirectory()));
-        sourceFiles = sourceFiles.map(sourceFile -> {
-            if (sourceFile.getSourcePath().startsWith(buildDirectory) || isExcluded(repository, exclusionMatchers, sourceFile.getSourcePath())) {
-                return null;
-            }
-            return sourceFile;
-        }).filter(Objects::nonNull);
+        sourceFiles = sourceFiles
+                .filter(sourceFile -> !sourceFile.getSourcePath().startsWith(buildDirectory) && !isExcluded(repository, exclusionMatchers, sourceFile.getSourcePath()));
 
         Stream<SourceFile> mavenWrapperFiles = parseMavenWrapperFiles(mavenProject, exclusionMatchers, parsedPaths, ctx);
         sourceFiles = Stream.concat(sourceFiles, mavenWrapperFiles);

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -222,12 +222,14 @@ public class MavenMojoProjectParser {
 
         // Pre-populate parsedPaths with all source paths from both scopes
         // to prevent resource parsers from claiming cross-scope sources as PlainText
-        parsedPaths.addAll(listJavaSources(mavenProject, mavenProject.getExecutionProject().getCompileSourceRoots()));
+        List<String> mainSourceRoots = filterGeneratedSourceRoots(mavenProject, mavenProject.getExecutionProject().getCompileSourceRoots());
+        List<String> testSourceRoots = filterGeneratedSourceRoots(mavenProject, mavenProject.getExecutionProject().getTestCompileSourceRoots());
+        parsedPaths.addAll(listJavaSources(mavenProject, mainSourceRoots));
         parsedPaths.addAll(listKotlinSources(mavenProject, "compile", mavenProject.getBuild().getSourceDirectory()));
-        parsedPaths.addAll(listGroovySources(mavenProject, mavenProject.getExecutionProject().getCompileSourceRoots()));
-        parsedPaths.addAll(listJavaSources(mavenProject, mavenProject.getExecutionProject().getTestCompileSourceRoots()));
+        parsedPaths.addAll(listGroovySources(mavenProject, mainSourceRoots));
+        parsedPaths.addAll(listJavaSources(mavenProject, testSourceRoots));
         parsedPaths.addAll(listKotlinSources(mavenProject, "test-compile", mavenProject.getBuild().getTestSourceDirectory()));
-        parsedPaths.addAll(listGroovySources(mavenProject, mavenProject.getExecutionProject().getTestCompileSourceRoots()));
+        parsedPaths.addAll(listGroovySources(mavenProject, testSourceRoots));
 
         if (scopes.contains(MAIN)) {
             sourceFiles = Stream.concat(sourceFiles, processMainSources(mavenProject, javaParserBuilder.clone(), kotlinParserBuilder.clone(), groovyParserBuilder.clone(), parsedPaths, ctx));
@@ -480,14 +482,18 @@ public class MavenMojoProjectParser {
 
         Stream<SourceFile> sourceFiles = Stream.of();
 
+        // Skip generated source roots under the build directory; their compiled classes are
+        // already on the classpath via getCompileClasspathElements() and available for type attribution.
+        List<String> sourceRoots = filterGeneratedSourceRoots(mavenProject, mavenProject.getExecutionProject().getCompileSourceRoots());
+
         // scan Java files
-        Collection<Path> mainJavaSources = listJavaSources(mavenProject, mavenProject.getExecutionProject().getCompileSourceRoots());
+        Collection<Path> mainJavaSources = listJavaSources(mavenProject, sourceRoots);
 
         // scan Kotlin files
         List<Path> mainKotlinSources = listKotlinSources(mavenProject, "compile", mavenProject.getBuild().getSourceDirectory());
 
         // scan Groovy files
-        List<Path> mainGroovySources = listGroovySources(mavenProject, mavenProject.getExecutionProject().getCompileSourceRoots());
+        List<Path> mainGroovySources = listGroovySources(mavenProject, sourceRoots);
 
         logInfo(mavenProject, "Parsing source files");
         List<Path> dependencies = mavenProject.getCompileClasspathElements().stream()
@@ -573,14 +579,18 @@ public class MavenMojoProjectParser {
 
         Stream<SourceFile> sourceFiles = Stream.of();
 
+        // Skip generated source roots under the build directory; their compiled classes are
+        // already on the classpath via getTestClasspathElements() and available for type attribution.
+        List<String> testSourceRoots = filterGeneratedSourceRoots(mavenProject, mavenProject.getExecutionProject().getTestCompileSourceRoots());
+
         // scan Java files
-        Collection<Path> testJavaSources = listJavaSources(mavenProject, mavenProject.getExecutionProject().getTestCompileSourceRoots());
+        Collection<Path> testJavaSources = listJavaSources(mavenProject, testSourceRoots);
 
         // scan Kotlin files
         List<Path> testKotlinSources = listKotlinSources(mavenProject, "test-compile", mavenProject.getBuild().getTestSourceDirectory());
 
         // scan Groovy files
-        List<Path> testGroovySources = listGroovySources(mavenProject, mavenProject.getExecutionProject().getTestCompileSourceRoots());
+        List<Path> testGroovySources = listGroovySources(mavenProject, testSourceRoots);
 
         List<Path> testDependencies = mavenProject.getTestClasspathElements().stream()
                 .distinct()
@@ -1001,6 +1011,13 @@ public class MavenMojoProjectParser {
                 throw new UncheckedIOException(e);
             }
         };
+    }
+
+    private static List<String> filterGeneratedSourceRoots(MavenProject mavenProject, List<String> sourceRoots) {
+        Path buildDirectory = Paths.get(mavenProject.getBuild().getDirectory());
+        return sourceRoots.stream()
+                .filter(root -> !Paths.get(root).startsWith(buildDirectory))
+                .collect(toList());
     }
 
     private static Collection<Path> listJavaSources(MavenProject mavenProject, List<String> compileSourceRoots) throws MojoExecutionException {

--- a/src/test/java/org/openrewrite/maven/MavenMojoProjectParserIsExcludedTest.java
+++ b/src/test/java/org/openrewrite/maven/MavenMojoProjectParserIsExcludedTest.java
@@ -168,7 +168,6 @@ class MavenMojoProjectParserIsExcludedTest {
                 .isTrue();
     }
 
-
     private static void writeFile(Path path, String content) throws Exception {
         Files.createDirectories(path.getParent());
         Files.write(path, content.getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/org/openrewrite/maven/MavenMojoProjectParserIsExcludedTest.java
+++ b/src/test/java/org/openrewrite/maven/MavenMojoProjectParserIsExcludedTest.java
@@ -52,7 +52,7 @@ class MavenMojoProjectParserIsExcludedTest {
             git.add().addFilepattern(".gitignore").call();
             git.commit().setMessage("initial").call();
 
-            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("generated.txt")))
+            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("target"), Path.of("generated.txt")))
                     .as("untracked gitignored file should be excluded")
                     .isTrue();
         }
@@ -71,7 +71,7 @@ class MavenMojoProjectParserIsExcludedTest {
             git.add().addFilepattern(".gitignore").call();
             git.commit().setMessage("add gitignore").call();
 
-            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("tracked-ignored.txt")))
+            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("target"), Path.of("tracked-ignored.txt")))
                     .as("tracked gitignored file should NOT be excluded")
                     .isFalse();
         }
@@ -88,7 +88,7 @@ class MavenMojoProjectParserIsExcludedTest {
             git.add().addFilepattern(".gitignore").call();
             git.commit().setMessage("initial").call();
 
-            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("target/output.txt")))
+            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("build"), Path.of("target/output.txt")))
                     .as("untracked file in gitignored directory should be excluded")
                     .isTrue();
         }
@@ -107,7 +107,7 @@ class MavenMojoProjectParserIsExcludedTest {
             git.add().addFilepattern(".gitignore").call();
             git.commit().setMessage("add gitignore").call();
 
-            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("target/output.txt")))
+            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("build"), Path.of("target/output.txt")))
                     .as("tracked file in gitignored directory should NOT be excluded")
                     .isFalse();
         }
@@ -118,7 +118,7 @@ class MavenMojoProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/secret.properties"));
 
-        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("config/secret.properties")))
+        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("target"), Path.of("config/secret.properties")))
                 .as("path matching exclusion pattern should be excluded")
                 .isTrue();
     }
@@ -128,7 +128,7 @@ class MavenMojoProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/secret.properties"));
 
-        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("config/application.properties")))
+        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("target"), Path.of("config/application.properties")))
                 .as("path not matching exclusion pattern should not be excluded")
                 .isFalse();
     }
@@ -140,7 +140,7 @@ class MavenMojoProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/pom.xml"));
 
-        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("pom.xml")))
+        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("target"), Path.of("pom.xml")))
                 .as("root-level file should match **/pom.xml via leading-slash prefixing")
                 .isTrue();
     }
@@ -152,7 +152,7 @@ class MavenMojoProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/pom.xml"));
 
-        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("/pom.xml")))
+        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("target"), Path.of("/pom.xml")))
                 .as("root-level file with leading slash should match **/pom.xml directly")
                 .isTrue();
     }
@@ -163,9 +163,23 @@ class MavenMojoProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/pom.xml"));
 
-        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("module/pom.xml")))
+        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("target"), Path.of("module/pom.xml")))
                 .as("subdirectory file should match **/pom.xml directly")
                 .isTrue();
+    }
+
+    @Test
+    void fileInBuildDirectoryIsExcluded() {
+        assertThat(MavenMojoProjectParser.isExcluded(null, emptyList(), Path.of("target"), Path.of("target/generated-sources/annotations/Foo.java")))
+                .as("file under build directory should be excluded")
+                .isTrue();
+    }
+
+    @Test
+    void fileOutsideBuildDirectoryIsNotExcluded() {
+        assertThat(MavenMojoProjectParser.isExcluded(null, emptyList(), Path.of("target"), Path.of("src/main/java/Foo.java")))
+                .as("file outside build directory should not be excluded")
+                .isFalse();
     }
 
     private static void writeFile(Path path, String content) throws Exception {

--- a/src/test/java/org/openrewrite/maven/MavenMojoProjectParserIsExcludedTest.java
+++ b/src/test/java/org/openrewrite/maven/MavenMojoProjectParserIsExcludedTest.java
@@ -52,7 +52,7 @@ class MavenMojoProjectParserIsExcludedTest {
             git.add().addFilepattern(".gitignore").call();
             git.commit().setMessage("initial").call();
 
-            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("target"), Path.of("generated.txt")))
+            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("generated.txt")))
                     .as("untracked gitignored file should be excluded")
                     .isTrue();
         }
@@ -71,7 +71,7 @@ class MavenMojoProjectParserIsExcludedTest {
             git.add().addFilepattern(".gitignore").call();
             git.commit().setMessage("add gitignore").call();
 
-            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("target"), Path.of("tracked-ignored.txt")))
+            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("tracked-ignored.txt")))
                     .as("tracked gitignored file should NOT be excluded")
                     .isFalse();
         }
@@ -88,7 +88,7 @@ class MavenMojoProjectParserIsExcludedTest {
             git.add().addFilepattern(".gitignore").call();
             git.commit().setMessage("initial").call();
 
-            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("build"), Path.of("target/output.txt")))
+            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("target/output.txt")))
                     .as("untracked file in gitignored directory should be excluded")
                     .isTrue();
         }
@@ -107,7 +107,7 @@ class MavenMojoProjectParserIsExcludedTest {
             git.add().addFilepattern(".gitignore").call();
             git.commit().setMessage("add gitignore").call();
 
-            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("build"), Path.of("target/output.txt")))
+            assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("target/output.txt")))
                     .as("tracked file in gitignored directory should NOT be excluded")
                     .isFalse();
         }
@@ -118,7 +118,7 @@ class MavenMojoProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/secret.properties"));
 
-        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("target"), Path.of("config/secret.properties")))
+        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("config/secret.properties")))
                 .as("path matching exclusion pattern should be excluded")
                 .isTrue();
     }
@@ -128,7 +128,7 @@ class MavenMojoProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/secret.properties"));
 
-        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("target"), Path.of("config/application.properties")))
+        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("config/application.properties")))
                 .as("path not matching exclusion pattern should not be excluded")
                 .isFalse();
     }
@@ -140,7 +140,7 @@ class MavenMojoProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/pom.xml"));
 
-        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("target"), Path.of("pom.xml")))
+        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("pom.xml")))
                 .as("root-level file should match **/pom.xml via leading-slash prefixing")
                 .isTrue();
     }
@@ -152,7 +152,7 @@ class MavenMojoProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/pom.xml"));
 
-        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("target"), Path.of("/pom.xml")))
+        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("/pom.xml")))
                 .as("root-level file with leading slash should match **/pom.xml directly")
                 .isTrue();
     }
@@ -163,24 +163,11 @@ class MavenMojoProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/pom.xml"));
 
-        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("target"), Path.of("module/pom.xml")))
+        assertThat(MavenMojoProjectParser.isExcluded(null, matchers, Path.of("module/pom.xml")))
                 .as("subdirectory file should match **/pom.xml directly")
                 .isTrue();
     }
 
-    @Test
-    void fileInBuildDirectoryIsExcluded() {
-        assertThat(MavenMojoProjectParser.isExcluded(null, emptyList(), Path.of("target"), Path.of("target/generated-sources/annotations/Foo.java")))
-                .as("file under build directory should be excluded")
-                .isTrue();
-    }
-
-    @Test
-    void fileOutsideBuildDirectoryIsNotExcluded() {
-        assertThat(MavenMojoProjectParser.isExcluded(null, emptyList(), Path.of("target"), Path.of("src/main/java/Foo.java")))
-                .as("file outside build directory should not be excluded")
-                .isFalse();
-    }
 
     private static void writeFile(Path path, String content) throws Exception {
         Files.createDirectories(path.getParent());


### PR DESCRIPTION
## Summary

- Generated sources under the build directory (e.g. `target/generated-sources/`) were being fully parsed into LSTs only to be filtered out afterward
- Since `getCompileClasspathElements()` already includes `target/classes` with the compiled `.class` files, type attribution works without parsing the generated sources
- Adds `filterGeneratedSourceRoots()` to exclude source roots under the build directory before scanning, applied consistently in `processMainSources()`, `processTestSources()`, and the `parsedPaths` pre-population
- This improves performance for projects that heavily use code generation (protobuf, MapStruct, annotation processors, etc.)

- Closes #667

## Impact on related issues

- **#968** — Requests generated sources be scanned (for search recipes) but not modified. This PR does not regress that use case: generated sources were already fully discarded after parsing, so search results from them were already lost. Properly supporting #968 would require a `GeneratedSource` marker, which is orthogonal to this change.
- **#1107** — Recipes no longer applied to generated sources after 6.27+. This PR does not change the filtering behavior introduced in 6.27 (PR #665); it only moves the exclusion earlier (before parsing instead of after). Users who want recipes applied to generated sources need a separate opt-in mechanism.
- **#649** — Maven Polyglot `ParseError`. Unrelated; that issue is about non-standard POM files, not source file handling.

## Test plan
- [x] Existing unit tests pass (16/16)
- [ ] Integration test with a project using annotation processing (e.g. MapStruct or Lombok) to verify type attribution still works
- [ ] Integration test with a protobuf project to verify generated types resolve correctly