### PR TITLE
Fix plexus-utils CVE-2025-67030 suppression

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <!-- False positive: 3.6.1 contains the Zip Slip fix but CVE lists <4.0.3 as affected -->
-    <suppress until="2026-05-08Z">
+    <suppress until="2026-05-01Z">
         <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-utils@.*$</packageUrl>
-        <vulnerabilityName>CVE-2025-67030</vulnerabilityName>
+        <cve>CVE-2025-67030</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
## Summary
- Fix the existing suppression for CVE-2025-67030 (plexus-utils directory traversal)
- Changed `<vulnerabilityName>` to `<cve>` — NVD-sourced vulnerabilities require the `<cve>` element to be matched by the OWASP dependency-check plugin
- The suppression was already in place but wasn't being applied because of this mismatch

plexus-utils 3.6.1 is the patched version (advisory says `< 3.6.1` is vulnerable), but the GHSA database hasn't updated the range yet, so the scanner still flags it.

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1044

## Test plan
- [ ] Verify `dependency-check-maven:check` no longer reports CVE-2025-67030 for plexus-utils 3.6.1