### PR TITLE
Move dependency-check-maven plugin from reporting to build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,11 +507,6 @@
                     </execution>
                 </executions>
             </plugin>
-        </plugins>
-    </build>
-
-    <reporting>
-        <plugins>
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
@@ -524,14 +519,12 @@
                     </suppressionFiles>
                     <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
                 </configuration>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>aggregate</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
             </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-report-plugin</artifactId>


### PR DESCRIPTION
## Summary
- Move the OWASP dependency-check-maven plugin from `<reporting>` to `<build><plugins>`
- The vulnerability scan workflow runs `mvn org.owasp:dependency-check-maven:check` directly, which only reads `<build>` config — the `<reporting>` section is only used during `mvn site`
- This means `suppressions.xml` was never being applied, causing suppressed CVEs to keep appearing in reports

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1044

## Test plan
- [ ] `mvn org.owasp:dependency-check-maven:check` should now apply suppressions.xml
- [ ] CVE-2025-67030 (plexus-utils) should no longer appear in scan output