### PR TITLE
Suppress Maven transfer progress via .mvn/maven.config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,10 @@ jobs:
             echo "DEVELOCITY_ACCESS_KEY=" >> $GITHUB_ENV
           fi
       - name: build
-        run: ./mvnw --show-version --no-transfer-progress --update-snapshots clean verify --file=pom.xml --fail-at-end --batch-mode -Dstyle.color=always
+        run: ./mvnw --show-version --update-snapshots clean verify --file=pom.xml --fail-at-end --batch-mode -Dstyle.color=always
       - name: publish-snapshots
         if: github.event_name != 'pull_request'
-        run: ./mvnw --show-version --no-transfer-progress --settings=${{ github.workspace }}/settings.xml --file=pom.xml --batch-mode -Dstyle.color=always --activate-profiles=sign-artifacts clean deploy -DskipTests
+        run: ./mvnw --show-version --settings=${{ github.workspace }}/settings.xml --file=pom.xml --batch-mode -Dstyle.color=always --activate-profiles=sign-artifacts clean deploy -DskipTests
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,7 +38,7 @@ jobs:
           java-version: 17
           cache: maven
       - name: site
-        run: ./mvnw --show-version --no-transfer-progress --update-snapshots clean site --file=pom.xml --fail-at-end --batch-mode -Dstyle.color=always -Ddependency-check.skip=true
+        run: ./mvnw --show-version --update-snapshots clean site --file=pom.xml --fail-at-end --batch-mode -Dstyle.color=always -Ddependency-check.skip=true
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--no-transfer-progress


### PR DESCRIPTION
## Summary
- Add `.mvn/maven.config` containing `--no-transfer-progress` so every `mvnw` invocation (CI and local) skips download progress output, like the noise seen in [this run](https://github.com/openrewrite/rewrite-maven-plugin/actions/runs/26053969048/job/76597321996).
- Drop the now-redundant `--no-transfer-progress` flag from `ci.yml` and `pages.yml`.

## Test plan
- [ ] Verify CI logs no longer contain `Downloading`/`Downloaded` progress lines.