### PR TITLE
Validate compiler version properties and read pluginManagement for JavaVersion

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -363,36 +363,30 @@ public class MavenMojoProjectParser {
         String sourceCompatibility = null;
         String targetCompatibility = null;
 
-        Plugin compilerPlugin = mavenProject.getPlugin(MAVEN_COMPILER_PLUGIN);
+        Plugin compilerPlugin = getCompilerPlugin(mavenProject);
         if (compilerPlugin != null && compilerPlugin.getConfiguration() instanceof Xpp3Dom) {
             Xpp3Dom dom = (Xpp3Dom) compilerPlugin.getConfiguration();
-            Xpp3Dom release = dom.getChild("release");
-            if (release != null && StringUtils.isNotEmpty(release.getValue()) && !release.getValue().contains("${")) {
-                sourceCompatibility = release.getValue();
-                targetCompatibility = release.getValue();
+            String release = compatibilityValue(dom.getChild("release"));
+            if (release != null) {
+                sourceCompatibility = release;
+                targetCompatibility = release;
             } else {
-                Xpp3Dom source = dom.getChild("source");
-                if (source != null && StringUtils.isNotEmpty(source.getValue()) && !source.getValue().contains("${")) {
-                    sourceCompatibility = source.getValue();
-                }
-                Xpp3Dom target = dom.getChild("target");
-                if (target != null && StringUtils.isNotEmpty(target.getValue()) && !target.getValue().contains("${")) {
-                    targetCompatibility = target.getValue();
-                }
+                sourceCompatibility = compatibilityValue(dom.getChild("source"));
+                targetCompatibility = compatibilityValue(dom.getChild("target"));
             }
         }
 
         if (sourceCompatibility == null || targetCompatibility == null) {
-            String propertiesReleaseCompatibility = (String) mavenProject.getProperties().get("maven.compiler.release");
+            String propertiesReleaseCompatibility = compatibilityProperty(mavenProject, "maven.compiler.release");
             if (propertiesReleaseCompatibility != null) {
                 sourceCompatibility = propertiesReleaseCompatibility;
                 targetCompatibility = propertiesReleaseCompatibility;
             } else {
-                String propertiesSourceCompatibility = (String) mavenProject.getProperties().get("maven.compiler.source");
+                String propertiesSourceCompatibility = compatibilityProperty(mavenProject, "maven.compiler.source");
                 if (sourceCompatibility == null && propertiesSourceCompatibility != null) {
                     sourceCompatibility = propertiesSourceCompatibility;
                 }
-                String propertiesTargetCompatibility = (String) mavenProject.getProperties().get("maven.compiler.target");
+                String propertiesTargetCompatibility = compatibilityProperty(mavenProject, "maven.compiler.target");
                 if (targetCompatibility == null && propertiesTargetCompatibility != null) {
                     targetCompatibility = propertiesTargetCompatibility;
                 }
@@ -406,36 +400,30 @@ public class MavenMojoProjectParser {
         String sourceCompatibility = null;
         String targetCompatibility = null;
 
-        Plugin compilerPlugin = mavenProject.getPlugin(MAVEN_COMPILER_PLUGIN);
+        Plugin compilerPlugin = getCompilerPlugin(mavenProject);
         if (compilerPlugin != null && compilerPlugin.getConfiguration() instanceof Xpp3Dom) {
             Xpp3Dom dom = (Xpp3Dom) compilerPlugin.getConfiguration();
-            Xpp3Dom release = dom.getChild("testRelease");
-            if (release != null && StringUtils.isNotEmpty(release.getValue()) && !release.getValue().contains("${")) {
-                sourceCompatibility = release.getValue();
-                targetCompatibility = release.getValue();
+            String release = compatibilityValue(dom.getChild("testRelease"));
+            if (release != null) {
+                sourceCompatibility = release;
+                targetCompatibility = release;
             } else {
-                Xpp3Dom source = dom.getChild("testSource");
-                if (source != null && StringUtils.isNotEmpty(source.getValue()) && !source.getValue().contains("${")) {
-                    sourceCompatibility = source.getValue();
-                }
-                Xpp3Dom target = dom.getChild("testTarget");
-                if (target != null && StringUtils.isNotEmpty(target.getValue()) && !target.getValue().contains("${")) {
-                    targetCompatibility = target.getValue();
-                }
+                sourceCompatibility = compatibilityValue(dom.getChild("testSource"));
+                targetCompatibility = compatibilityValue(dom.getChild("testTarget"));
             }
         }
 
         if (sourceCompatibility == null || targetCompatibility == null) {
-            String propertiesReleaseCompatibility = (String) mavenProject.getProperties().get("maven.compiler.testRelease");
+            String propertiesReleaseCompatibility = compatibilityProperty(mavenProject, "maven.compiler.testRelease");
             if (propertiesReleaseCompatibility != null) {
                 sourceCompatibility = propertiesReleaseCompatibility;
                 targetCompatibility = propertiesReleaseCompatibility;
             } else {
-                String propertiesSourceCompatibility = (String) mavenProject.getProperties().get("maven.compiler.testSource");
+                String propertiesSourceCompatibility = compatibilityProperty(mavenProject, "maven.compiler.testSource");
                 if (sourceCompatibility == null && propertiesSourceCompatibility != null) {
                     sourceCompatibility = propertiesSourceCompatibility;
                 }
-                String propertiesTargetCompatibility = (String) mavenProject.getProperties().get("maven.compiler.testTarget");
+                String propertiesTargetCompatibility = compatibilityProperty(mavenProject, "maven.compiler.testTarget");
                 if (targetCompatibility == null && propertiesTargetCompatibility != null) {
                     targetCompatibility = propertiesTargetCompatibility;
                 }
@@ -453,6 +441,31 @@ public class MavenMojoProjectParser {
         }
 
         return getJavaVersionMarker(sourceCompatibility, targetCompatibility);
+    }
+
+    private static @Nullable Plugin getCompilerPlugin(MavenProject mavenProject) {
+        return Optional.ofNullable(mavenProject.getPlugin(MAVEN_COMPILER_PLUGIN))
+                .orElseGet(() -> {
+                    PluginManagement pluginManagement = mavenProject.getPluginManagement();
+                    return pluginManagement != null ? pluginManagement.getPluginsAsMap().get(MAVEN_COMPILER_PLUGIN) : null;
+                });
+    }
+
+    private static @Nullable String compatibilityValue(@Nullable Xpp3Dom node) {
+        return node == null ? null : validCompatibility(node.getValue());
+    }
+
+    private static @Nullable String compatibilityProperty(MavenProject mavenProject, String key) {
+        return validCompatibility((String) mavenProject.getProperties().get(key));
+    }
+
+    /**
+     * A usable Java compatibility level: non-empty and not an unresolved {@code ${...}} property
+     * placeholder. Returning {@code null} for unusable values keeps them from reaching the
+     * {@link JavaVersion} marker, where they would parse to a {@code -1} major version.
+     */
+    private static @Nullable String validCompatibility(@Nullable String value) {
+        return value != null && StringUtils.isNotEmpty(value) && !value.contains("${") ? value : null;
     }
 
     private static JavaVersion getJavaVersionMarker(@Nullable String sourceCompatibility, @Nullable String targetCompatibility) {

--- a/src/test/java/org/openrewrite/maven/MavenMojoProjectParserTest.java
+++ b/src/test/java/org/openrewrite/maven/MavenMojoProjectParserTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.maven;
 
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginManagement;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +40,55 @@ class MavenMojoProjectParserTest {
         JavaVersion marker = MavenMojoProjectParser.getSrcTestJavaVersion(new MavenProject());
         assertThat(marker.getSourceCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
         assertThat(marker.getTargetCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
+    }
+
+    @DisplayName("Unresolved maven.compiler property placeholder falls back to java.specification.version")
+    @Test
+    void unresolvedCompilerPropertyPlaceholderFallsBackToRuntime() {
+        MavenProject mavenProject = new MavenProject();
+        mavenProject.getProperties().setProperty("maven.compiler.source", "${java.version}");
+        mavenProject.getProperties().setProperty("maven.compiler.target", "${java.version}");
+
+        JavaVersion marker = MavenMojoProjectParser.getSrcTestJavaVersion(mavenProject);
+        assertThat(marker.getMajorVersion()).isNotEqualTo(-1);
+        assertThat(marker.getSourceCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
+        assertThat(marker.getTargetCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
+    }
+
+    @DisplayName("Empty maven.compiler property falls back to java.specification.version")
+    @Test
+    void emptyCompilerPropertyFallsBackToRuntime() {
+        MavenProject mavenProject = new MavenProject();
+        mavenProject.getProperties().setProperty("maven.compiler.release", "");
+
+        JavaVersion marker = MavenMojoProjectParser.getSrcTestJavaVersion(mavenProject);
+        assertThat(marker.getMajorVersion()).isNotEqualTo(-1);
+        assertThat(marker.getSourceCompatibility()).isEqualTo(System.getProperty("java.specification.version"));
+    }
+
+    @DisplayName("Java version is read from pluginManagement compiler plugin configuration")
+    @Test
+    void javaVersionReadFromPluginManagement() {
+        MavenProject mavenProject = new MavenProject();
+
+        Plugin compilerPlugin = new Plugin();
+        compilerPlugin.setGroupId("org.apache.maven.plugins");
+        compilerPlugin.setArtifactId("maven-compiler-plugin");
+        Xpp3Dom configuration = new Xpp3Dom("configuration");
+        Xpp3Dom release = new Xpp3Dom("release");
+        release.setValue("17");
+        configuration.addChild(release);
+        compilerPlugin.setConfiguration(configuration);
+
+        PluginManagement pluginManagement = new PluginManagement();
+        pluginManagement.addPlugin(compilerPlugin);
+        Build build = new Build();
+        build.setPluginManagement(pluginManagement);
+        mavenProject.setBuild(build);
+
+        JavaVersion marker = MavenMojoProjectParser.getSrcTestJavaVersion(mavenProject);
+        assertThat(marker.getSourceCompatibility()).isEqualTo("17");
+        assertThat(marker.getTargetCompatibility()).isEqualTo("17");
     }
 
     @DisplayName("getCharset should resolve encoding from property placeholder")


### PR DESCRIPTION
## What's changed

When building the `JavaVersion` marker for a Maven module, `getSrcMainJavaVersion`/`getSrcTestJavaVersion` read the Java level from the `maven-compiler-plugin` configuration and then fall back to the `maven.compiler.*` properties.

Two gaps caused a `-1` (unparseable) Java version to be recorded:

1. **The property fallback was unvalidated.** The plugin-`<configuration>` branch rejected empty values and unresolved `${...}` placeholders (`isNotEmpty(...) && !contains("${")`), but the `maven.compiler.source/target/release` property branch did not — an unresolved or empty property (e.g. `<maven.compiler.source>${java.version}</maven.compiler.source>` that never got interpolated) flowed straight into the marker and parsed to `-1`. The same validation now applies to property values.

2. **`<pluginManagement>` was ignored.** Version lookup used only `mavenProject.getPlugin(...)`, so a compiler plugin configured solely under `<pluginManagement>` was treated as absent. It now falls back to plugin management, mirroring `getCharset()`.

The validation and plugin lookup are factored into small helpers (`validCompatibility`, `compatibilityValue`, `compatibilityProperty`, `getCompilerPlugin`) shared by the main and test paths.

## Testing

Added `MavenMojoProjectParserTest` cases: an unresolved `${java.version}` property and an empty `maven.compiler.release` both fall back to `java.specification.version` (never `-1`), and a compiler plugin configured under `<pluginManagement>` is read.