### PR TITLE
Switch to packages.nuxeo.com in BasicIT

### DIFF
--- a/src/test/java/org/openrewrite/maven/BasicIT.java
+++ b/src/test/java/org/openrewrite/maven/BasicIT.java
@@ -75,7 +75,7 @@ class BasicIT {
     @MavenOption(value = MavenCLIOptions.SETTINGS, parameter = "settings-user.xml")
     @MavenProfile("example_profile_id")
     @MavenTest
-    @SystemProperty(value = "REPOSITORY_URL", content = "https://maven-eu.nuxeo.org/nexus/content/repositories/public/")
+    @SystemProperty(value = "REPOSITORY_URL", content = "https://packages.nuxeo.com/repository/maven-public/")
     void resolves_settings(MavenExecutionResult result) {
         assertThat(result)
                 .isSuccessful()


### PR DESCRIPTION
## What's changed?

In a single test switching `maven-eu.nuxeo.org` mirror to `packages.nuxeo.com`

## What's your motivation?

The CI started failing and I suspect this is because the Nuxeo guys have discontinued/changed the infra of their service.