### PR TITLE
Always parse non-project resources

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
@@ -235,7 +235,7 @@ public abstract class AbstractRewriteBaseRunMojo extends AbstractRewriteMojo {
         List<NamedStyles> styles = loadStyles(project, env);
 
         //Parse and collect source files from each project in the maven session.
-        MavenMojoProjectParser projectParser = new MavenMojoProjectParser(getLog(), repositoryRoot, pomCacheEnabled, pomCacheDirectory, runtime, skipMavenParsing, getExclusions(), getPlainTextMasks(), sizeThresholdMb, mavenSession, settingsDecrypter, runPerSubmodule, true);
+        MavenMojoProjectParser projectParser = new MavenMojoProjectParser(getLog(), repositoryRoot, pomCacheEnabled, pomCacheDirectory, runtime, skipMavenParsing, getExclusions(), getPlainTextMasks(), sizeThresholdMb, mavenSession, settingsDecrypter, runPerSubmodule);
 
         Stream<SourceFile> sourceFiles = projectParser.listSourceFiles(project, ctx);
         List<SourceFile> sourceFileList = sourcesWithAutoDetectedStyles(sourceFiles, styles);

--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -145,10 +145,9 @@ public class MavenMojoProjectParser {
     private final MavenSession mavenSession;
     private final SettingsDecrypter settingsDecrypter;
     private final boolean runPerSubmodule;
-    private final boolean parseAdditionalResources;
 
     @SuppressWarnings("BooleanParameter")
-    public MavenMojoProjectParser(Log logger, Path baseDir, boolean pomCacheEnabled, @Nullable String pomCacheDirectory, RuntimeInformation runtime, boolean skipMavenParsing, Collection<String> exclusions, Collection<String> plainTextMasks, int sizeThresholdMb, MavenSession session, SettingsDecrypter settingsDecrypter, boolean runPerSubmodule, boolean parseAdditionalResources) {
+    public MavenMojoProjectParser(Log logger, Path baseDir, boolean pomCacheEnabled, @Nullable String pomCacheDirectory, RuntimeInformation runtime, boolean skipMavenParsing, Collection<String> exclusions, Collection<String> plainTextMasks, int sizeThresholdMb, MavenSession session, SettingsDecrypter settingsDecrypter, boolean runPerSubmodule) {
         this.logger = logger;
         this.baseDir = baseDir;
         this.repository = getRepository(baseDir);
@@ -162,7 +161,6 @@ public class MavenMojoProjectParser {
         this.mavenSession = session;
         this.settingsDecrypter = settingsDecrypter;
         this.runPerSubmodule = runPerSubmodule;
-        this.parseAdditionalResources = parseAdditionalResources;
     }
 
     protected JavaTypeCache createTypeCache() {
@@ -1097,9 +1095,6 @@ public class MavenMojoProjectParser {
     }
 
     protected Stream<SourceFile> parseNonProjectResources(MavenProject mavenProject, Set<Path> parsedPaths, ExecutionContext ctx) {
-        if (!parseAdditionalResources) {
-            return Stream.empty();
-        }
         //Collect any additional yaml/properties/xml files that are NOT already in a source set.
         OmniParser omniParser = omniParser(parsedPaths, mavenProject);
         List<Path> accepted = omniParser.acceptedPaths(baseDir, mavenProject.getBasedir().toPath());


### PR DESCRIPTION
Earlier the CLI depended on the maven plugin and required non-project resource parsing to be optional, which is why `MavenMojoProjectParser` carried a `parseAdditionalResources` flag. That accommodation is no longer necessary, so this removes the flag (the field, constructor parameter, and early-return guard) and always parses non-project resources. The maven plugin already passed `true`, so behavior is unchanged.