### PR TITLE
Tolerate Develocity remote build cache warnings in BasicIT

### DIFF
--- a/src/test/java/org/openrewrite/maven/BasicIT.java
+++ b/src/test/java/org/openrewrite/maven/BasicIT.java
@@ -36,7 +36,19 @@ class BasicIT {
                 .isSuccessful()
                 .out()
                 .warn()
+                .filteredOn(BasicIT::isNotIgnorableWarning)
                 .containsOnly("JAR will be empty - no content was marked for inclusion!");
+    }
+
+    /**
+     * Filters out environment-dependent warnings that may or may not appear depending on where the build runs:
+     * the Mac OS X RocksDB warning (https://github.com/openrewrite/rewrite-maven-plugin/issues/506) and the
+     * Develocity remote build cache warnings emitted when the cache is unavailable (e.g. a 403 on forked PR builds).
+     */
+    private static boolean isNotIgnorableWarning(String warn) {
+        return !"Unable to initialize RocksdbMavenPomCache, falling back to InMemoryMavenPomCache".equals(warn) &&
+               !(warn.startsWith("Could not store entry ") && warn.contains("remote build cache")) &&
+               !"The remote build cache was disabled during the build due to errors.".equals(warn);
     }
 
     @Disabled
@@ -54,8 +66,7 @@ class BasicIT {
                 .isSuccessful()
                 .out()
                 .warn()
-                // Ignore warning logged on Mac OS X; https://github.com/openrewrite/rewrite-maven-plugin/issues/506
-                .filteredOn(warn -> !"Unable to initialize RocksdbMavenPomCache, falling back to InMemoryMavenPomCache".equals(warn))
+                .filteredOn(BasicIT::isNotIgnorableWarning)
                 .isEmpty();
     }
 
@@ -92,8 +103,7 @@ class BasicIT {
                 .isSuccessful()
                 .out()
                 .warn()
-                // Ignore warning logged on Mac OS X; https://github.com/openrewrite/rewrite-maven-plugin/issues/506
-                .filteredOn(warn -> !"Unable to initialize RocksdbMavenPomCache, falling back to InMemoryMavenPomCache".equals(warn))
+                .filteredOn(BasicIT::isNotIgnorableWarning)
                 .isEmpty();
         assertThat(result).out().info().contains("Running recipe(s)...");
     }


### PR DESCRIPTION
## Problem

The scheduled `ci` run on `main` ([run 28331369431](https://github.com/openrewrite/rewrite-maven-plugin/actions/runs/28331369431)) failed two integration tests in `BasicIT`: `groupid_artifactid_should_be_ok` and `snapshot_ok`.

Both assert the child Maven build's warning output strictly. Scheduled CI runs (and forked/dependabot PR builds) don't have remote build cache *write* credentials, so the Develocity extension emits:

```
Could not store entry <hash> in remote build cache: Storing entry at 'https://ge.openrewrite.org/cache/<hash>' response status 403: Forbidden
The remote build cache was disabled during the build due to errors.
```

These leaked into the asserted output and broke `containsOnly(...)` / `isEmpty()`.

## Fix

Filter out these environment-dependent cache warnings, consolidating with the existing Mac OS X RocksDB warning filter into a shared `isNotIgnorableWarning` predicate.