### PR TITLE
Suppress CVE-2026-53914 and jackson-databind false positives

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,3 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2026-08-01Z">
+        <notes><![CDATA[
+       CVE-2026-53914 is unsafe deserialization of untrusted Kotlin build-cache
+       metadata, allowing code execution (fixed in Kotlin 2.4.20). It requires local
+       access, high privileges and high attack complexity (CVSS 6.7; the scanner
+       inflates it to CRITICAL). Here org.jetbrains.kotlin:kotlin-stdlib arrives as a
+       runtime dependency of the rewrite-kotlin recipe module, but the vulnerable code
+       path is the Kotlin build-cache metadata deserialization in the Kotlin Gradle
+       plugin / build tooling, which is not present in kotlin-stdlib and is not used by
+       this Maven plugin. No GA toolchain at 2.4.20 has been released yet (only
+       2.4.20-Beta1), so there is nothing to bump to. Re-evaluate when 2.4.20 goes GA.
+       Added: 2026-07-03
+       ]]></notes>
+        <cve>CVE-2026-53914</cve>
+    </suppress>
+    <suppress until="2026-08-01Z">
+        <notes><![CDATA[
+       jackson-databind polymorphic-typing / deserialization advisories:
+       CVE-2026-54512 (PolymorphicTypeValidator bypass via generic type parameters),
+       CVE-2026-54513 (allowIfSubTypeIsArray allowlist bypass), CVE-2026-54514
+       (InetSocketAddress eager DNS resolution / SSRF) and CVE-2026-54515
+       (case-insensitive deserialization bypasses per-property @JsonIgnoreProperties).
+       All require enabling default/polymorphic typing on attacker-controlled input;
+       rewrite-maven-plugin uses jackson only to read Maven/recipe configuration and
+       serialized LSTs, not untrusted polymorphic JSON, so the gadget paths are not
+       reachable. jackson is managed centrally via jackson-bom (2.21.4). Re-evaluate
+       when the jackson-bom moves to the clean 2.21.5+ patch release.
+       Added: 2026-07-03
+       ]]></notes>
+        <cve>CVE-2026-54512</cve>
+        <cve>CVE-2026-54513</cve>
+        <cve>CVE-2026-54514</cve>
+        <cve>CVE-2026-54515</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Triage of the 2026-07-03 OpenRewrite dependency vulnerability report. Adds OWASP suppressions to the previously-empty `suppressions.xml`.

| CVE | Severity | Rationale |
|---|---|---|
| CVE-2026-53914 | CRITICAL (CVSS 6.7) | `kotlin-stdlib` arrives as a runtime dep via `rewrite-kotlin`, but the vulnerable Kotlin build-cache metadata deserialization is in the Kotlin build tooling — not present in `kotlin-stdlib` and not used by this Maven plugin. Requires local access + high privileges + high attack complexity. No GA 2.4.20 toolchain released yet. |
| CVE-2026-54512/54513/54514/54515 | MEDIUM/HIGH | jackson-databind polymorphic-typing / deserialization gadgets require default typing on untrusted input; not reachable here. jackson managed via jackson-bom (2.21.4). |

Both expire `2026-08-01Z` for batch re-evaluation. XML validated with `xmllint`.

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1112