### PR TITLE
Read the git index once instead of per source file

### DIFF
--- a/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
+++ b/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java
@@ -50,6 +50,7 @@ import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.jgit.api.Git;
+import org.openrewrite.jgit.dircache.DirCache;
 import org.openrewrite.jgit.lib.ObjectId;
 import org.openrewrite.jgit.revwalk.RevCommit;
 import org.openrewrite.jgit.revwalk.RevWalk;
@@ -130,6 +131,8 @@ public class MavenMojoProjectParser {
     private final AtomicBoolean firstWarningLogged = new AtomicBoolean(false);
     private final Path baseDir;
     private final org.openrewrite.jgit.lib.@Nullable Repository repository;
+    private @Nullable DirCache dirCache;
+    private boolean dirCacheInitialized;
     private final boolean pomCacheEnabled;
 
     @Nullable
@@ -227,8 +230,9 @@ public class MavenMojoProjectParser {
                 .map(pattern -> baseDir.getFileSystem().getPathMatcher("glob:" + pattern))
                 .collect(toList());
         Path buildDirectory = baseDir.relativize(Paths.get(mavenProject.getBuild().getDirectory()));
+        DirCache dirCache = dirCache();
         sourceFiles = sourceFiles
-                .filter(sourceFile -> !sourceFile.getSourcePath().startsWith(buildDirectory) && !isExcluded(repository, exclusionMatchers, sourceFile.getSourcePath()));
+                .filter(sourceFile -> !sourceFile.getSourcePath().startsWith(buildDirectory) && !isExcluded(repository, dirCache, exclusionMatchers, sourceFile.getSourcePath()));
 
         Stream<SourceFile> mavenWrapperFiles = parseMavenWrapperFiles(mavenProject, exclusionMatchers, parsedPaths, ctx);
         sourceFiles = Stream.concat(sourceFiles, mavenWrapperFiles);
@@ -241,7 +245,33 @@ public class MavenMojoProjectParser {
                 .map(this::logParseErrors);
     }
 
+    private @Nullable DirCache dirCache() {
+        if (!dirCacheInitialized) {
+            dirCacheInitialized = true;
+            if (repository != null) {
+                try {
+                    dirCache = repository.readDirCache();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        }
+        return dirCache;
+    }
+
     static boolean isExcluded(org.openrewrite.jgit.lib.@Nullable Repository repository, Collection<PathMatcher> exclusionMatchers, Path path) {
+        DirCache dirCache = null;
+        if (repository != null) {
+            try {
+                dirCache = repository.readDirCache();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return isExcluded(repository, dirCache, exclusionMatchers, path);
+    }
+
+    static boolean isExcluded(org.openrewrite.jgit.lib.@Nullable Repository repository, @Nullable DirCache dirCache, Collection<PathMatcher> exclusionMatchers, Path path) {
         for (PathMatcher excluded : exclusionMatchers) {
             if (excluded.matches(path)) {
                 return true;
@@ -258,8 +288,8 @@ public class MavenMojoProjectParser {
             }
         }
 
-        if (repository != null) {
-            return GitIgnore.isIgnoredAndUntracked(repository, separatorsToUnix(path.toString()));
+        if (repository != null && dirCache != null) {
+            return GitIgnore.isIgnoredAndUntracked(repository, dirCache, separatorsToUnix(path.toString()));
         }
         return false;
     }
@@ -1086,7 +1116,7 @@ public class MavenMojoProjectParser {
                             MavenWrapper.WRAPPER_SCRIPT_LOCATION)
                     .map(Path::toAbsolutePath)
                     .filter(Files::exists)
-                    .filter(it -> !isExcluded(repository, exclusions, it))
+                    .filter(it -> !isExcluded(repository, dirCache(), exclusions, it))
                     .filter(omniParser::accept)
                     .collect(toList());
             sourceFiles = omniParser.parse(mavenWrapperFiles, baseDir, ctx);

--- a/src/test/java/org/openrewrite/maven/MavenMojoProjectParserIsExcludedTest.java
+++ b/src/test/java/org/openrewrite/maven/MavenMojoProjectParserIsExcludedTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.maven;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.jgit.api.Git;
+import org.openrewrite.jgit.dircache.DirCache;
 import org.openrewrite.jgit.lib.Repository;
 
 import java.nio.charset.StandardCharsets;
@@ -110,6 +111,38 @@ class MavenMojoProjectParserIsExcludedTest {
             assertThat(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("target/output.txt")))
                     .as("tracked file in gitignored directory should NOT be excluded")
                     .isFalse();
+        }
+    }
+
+    @Test
+    void sharedDirCacheMatchesPerCallResult(@TempDir Path tempDir) throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Repository repo = git.getRepository();
+
+            writeFile(tempDir.resolve(".gitignore"), "generated.txt\n");
+            writeFile(tempDir.resolve("generated.txt"), "untracked content");
+            writeFile(tempDir.resolve("tracked-ignored.txt"), "content");
+            git.add().addFilepattern("tracked-ignored.txt").call();
+            writeFile(tempDir.resolve(".gitignore"), "generated.txt\ntracked-ignored.txt\n");
+            git.add().addFilepattern(".gitignore").call();
+            git.commit().setMessage("initial").call();
+
+            DirCache dirCache = repo.readDirCache();
+
+            assertThat(MavenMojoProjectParser.isExcluded(repo, dirCache, emptyList(), Path.of("generated.txt")))
+                    .as("untracked gitignored file, evaluated against a shared DirCache")
+                    .isTrue()
+                    .isEqualTo(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("generated.txt")));
+
+            assertThat(MavenMojoProjectParser.isExcluded(repo, dirCache, emptyList(), Path.of("tracked-ignored.txt")))
+                    .as("tracked gitignored file, evaluated against a shared DirCache")
+                    .isFalse()
+                    .isEqualTo(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("tracked-ignored.txt")));
+
+            assertThat(MavenMojoProjectParser.isExcluded(repo, dirCache, emptyList(), Path.of("not-ignored.txt")))
+                    .as("non-ignored file, evaluated against a shared DirCache")
+                    .isFalse()
+                    .isEqualTo(MavenMojoProjectParser.isExcluded(repo, emptyList(), Path.of("not-ignored.txt")));
         }
     }
 


### PR DESCRIPTION
## Problem

`MavenMojoProjectParser.isExcluded()` calls `GitIgnore.isIgnoredAndUntracked(repository, path)` once per source file, and each call runs `repository.readDirCache()`, re-parsing the entire `.git/index` from disk. On a large repo (e.g. 40k sources, 100k-entry index) this is O(sources × index-size) — JFR profiling on a monorepo shows build CPU dominated by `DirCache.read()` / `DirCacheEntry` construction.

- Fixes #1176.

## Change

- Read the `DirCache` **once** per parser instance (memoized, lazy) and reuse it for every path via the new rewrite-core overload `GitIgnore.isIgnoredAndUntracked(Repository, DirCache, …)` added in openrewrite/rewrite#8317.
- New `isExcluded(repository, dirCache, matchers, path)` overload; the existing 3-arg method delegates to it (reading the index itself), so behavior and existing callers/tests are unchanged.
- Hot call sites (main-source filter, Maven wrapper files) now pass the memoized `dirCache()`.

The index is treated as a stable snapshot for the duration of a build, which matches how the checks already behaved (they re-read the same on-disk index each time).

## Tests

Added `sharedDirCacheMatchesPerCallResult`, asserting the `DirCache` overload returns the same result as the per-call method for ignored+untracked, ignored-but-tracked, and non-ignored paths. Full `MavenMojoProjectParserIsExcludedTest` passes (10/10).

## Dependency

- Requires a `rewrite.version` that includes openrewrite/rewrite#8317 (the `DirCache` overload). The current `8.88.0-SNAPSHOT` will resolve it once rewrite republishes the snapshot post-merge.