### PR TITLE
Allow resolving dependencies from the Code Genome Project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,16 @@ jobs:
           server-password: SONATYPE_PASSWORD
           gpg-private-key: ${{ secrets.OSSRH_SIGNING_KEY }}
           gpg-passphrase: SONATYPE_SIGNING_PASSWORD
+      # setup-java writes a single server per call, and the settings above are only read by the
+      # steps that pass --settings; this second call supplies the default ~/.m2/settings.xml that
+      # the build step uses to authenticate against codegenome.
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          server-id: codegenome
+          server-username: CODEGENOME_USERNAME
+          server-password: CODEGENOME_TOKEN
       - name: validate-develocity-access-key
         run: |
           if [ -n "$DEVELOCITY_ACCESS_KEY" ] && ! echo "$DEVELOCITY_ACCESS_KEY" | grep -q '='; then
@@ -48,6 +58,11 @@ jobs:
           fi
       - name: build
         run: ./mvnw --show-version --update-snapshots clean verify --file=pom.xml --fail-at-end --batch-mode -Dstyle.color=always
+        env:
+          # Activates the codegenome profile in pom.xml; empty on pull requests from forks, which
+          # receive no secrets, leaving the profile inactive.
+          CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+          CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
       - name: publish-snapshots
         if: github.event_name != 'pull_request'
         run: ./mvnw --show-version --settings=${{ github.workspace }}/settings.xml --file=pom.xml --batch-mode -Dstyle.color=always --activate-profiles=sign-artifacts clean deploy -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -534,6 +534,33 @@
 
     <profiles>
         <profile>
+            <id>codegenome</id>
+            <activation>
+                <property>
+                    <name>env.CODEGENOME_USERNAME</name>
+                </property>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>codegenome</id>
+                    <url>https://artifacts.codegenomeproject.org/maven</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>codegenome</id>
+                    <url>https://artifacts.codegenomeproject.org/maven</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+
+        <profile>
             <id>sign-artifacts</id>
             <build>
                 <plugins>


### PR DESCRIPTION
Adds `https://artifacts.codegenomeproject.org/maven` as an additional source for `org.openrewrite` artifacts and forwards `CGP_ARTIFACTS_MAVEN_USERNAME` / `CGP_ARTIFACTS_MAVEN_TOKEN` to the CI build, the Maven counterpart to openrewrite/rewrite-github-actions@56b1b07 (where the Gradle convention plugin already does this). It sits alongside the existing repositories rather than replacing them, because CGP does not yet publish every snapshot we consume — `org.openrewrite:rewrite-bom:8.89.0-SNAPSHOT` returns 422 "no snapshot matching ... is published", while `rewrite-core`, `rewrite-java`, `rewrite-maven` and `rewrite-polyglot` are all present.

The repository is gated behind a `codegenome` profile activated by `CODEGENOME_USERNAME`, since CGP rejects anonymous requests and an unconditional declaration would 401 for contributors and fork PRs, which receive no secrets. `setup-java` is invoked a second time to write the default `~/.m2/settings.xml` the build step uses, as it emits only one server per call and the existing settings are read solely by the steps passing `--settings`. Publishing is untouched and still goes to Sonatype; switching that to CGP is a separate follow-up.