### PR TITLE
Renew OWASP suppressions through 2026-09-01

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2026-08-01Z">
+    <suppress until="2026-09-01Z">
         <notes><![CDATA[
        CVE-2026-53914 is unsafe deserialization of untrusted Kotlin build-cache
        metadata, allowing code execution (fixed in Kotlin 2.4.20). It requires local
@@ -9,13 +9,15 @@
        runtime dependency of the rewrite-kotlin recipe module, but the vulnerable code
        path is the Kotlin build-cache metadata deserialization in the Kotlin Gradle
        plugin / build tooling, which is not present in kotlin-stdlib and is not used by
-       this Maven plugin. No GA toolchain at 2.4.20 has been released yet (only
-       2.4.20-Beta1), so there is nothing to bump to. Re-evaluate when 2.4.20 goes GA.
+       this Maven plugin. No GA toolchain at 2.4.20 has been released yet (as of
+       2026-08-03 Maven Central has only 2.4.20-Beta2), so there is nothing to bump to.
+       Re-evaluate when 2.4.20 goes GA.
        Added: 2026-07-03
        ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/.*@.*$</packageUrl>
         <cve>CVE-2026-53914</cve>
     </suppress>
-    <suppress until="2026-08-01Z">
+    <suppress until="2026-09-01Z">
         <notes><![CDATA[
        jackson-databind polymorphic-typing / deserialization advisories:
        CVE-2026-54512 (PolymorphicTypeValidator bypass via generic type parameters),
@@ -29,6 +31,7 @@
        when the jackson-bom moves to the clean 2.21.5+ patch release.
        Added: 2026-07-03
        ]]></notes>
+       <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@.*$</packageUrl>
         <cve>CVE-2026-54512</cve>
         <cve>CVE-2026-54513</cve>
         <cve>CVE-2026-54514</cve>


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1139

Both suppression blocks in this file carried `until="2026-08-01Z"` and lapsed before the 2026-08-03 scan. After the Gradle-side suppression files were renewed and the rerun ([run 30823638259](https://github.com/moderneinc/dependency-vulnerability-reports/actions/runs/30823638259)) came back, this repo was the **only** remaining entry in the report — `kotlin-stdlib` 2.3.20 flagged CRITICAL for CVE-2026-53914.

This repo is scanned separately from the rest: it is a Maven build using `dependency-check-maven` with its own `suppressions.xml`, so it does not inherit the shared `rewrite-build-gradle-plugin` suppressions that cover the other ~90 modules.

### Changes

- **CVE-2026-53914** (Kotlin build-cache deserialization) renewed to 2026-09-01. Still nothing to bump to: the fix is Kotlin 2.4.20 and Maven Central has only `2.4.20-Beta2` as of 2026-08-03. Note corrected from "only 2.4.20-Beta1" accordingly.
- **CVE-2026-54512 … -54515** (jackson-databind polymorphic typing) renewed to 2026-09-01.

Both blocks were previously unscoped (no `packageUrl`), so they suppressed those CVE IDs against any artifact in the build. Each is now scoped to the artifact the rationale actually describes — `org.jetbrains.kotlin:*` and `com.fasterxml.jackson.core:jackson-databind` — matching how the same two blocks are written in `rewrite-recipe-bom` and the build plugin.

Validates with `xmllint`.