### PR TITLE
Bump license-maven-plugin to 5.1.1 and drop the unused git extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,8 +461,7 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <!-- 4.6 is the last version supporting Java 8 -->
-                <version>4.6</version>
+                <version>5.1.1</version>
                 <configuration>
                     <licenseSets>
                         <licenseSet>
@@ -482,14 +481,6 @@
                         </licenseSet>
                     </licenseSets>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.mycila</groupId>
-                        <artifactId>license-maven-plugin-git</artifactId>
-                        <!-- make sure you use the same version as license-maven-plugin -->
-                        <version>4.6</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>first</id>

--- a/src/test/java/org/openrewrite/maven/MavenMojoProjectParserIsExcludedTest.java
+++ b/src/test/java/org/openrewrite/maven/MavenMojoProjectParserIsExcludedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2020 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/openrewrite/maven/MavenPomCacheBuilderTest.java
+++ b/src/test/java/org/openrewrite/maven/MavenPomCacheBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2020 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Supersedes #1178 and #1179.

## Why #1179 fails

Dependabot split the coupled `com.mycila` pair into two PRs. #1179 bumps only `license-maven-plugin-git` and leaves the plugin at 4.6. The git artifact is a `PropertiesProvider` loaded into the plugin's classrealm via `META-INF/services`, so it is compiled against the core plugin's classes:

```
Caused by: java.lang.NoClassDefFoundError: com/mycila/maven/plugin/license/ShallowRepositorySkipException
	at java.util.ServiceLoader.getConstructor(ServiceLoader.java:674)
```

`ShallowRepositorySkipException` exists in `license-maven-plugin` 5.1.1 and not in 4.6, so the 5.1.1 provider cannot be constructed. #1178 avoids this by moving both halves together.

## What this PR does instead

**Removes `license-maven-plugin-git`.** It only supplies `license.git.copyrightCreationYear`, `license.git.copyrightLastYear`, `license.git.copyrightYears` and `license.git.copyrightExistenceYears`. Nothing here references those; `.mvn/licenseHeader.txt` uses `${year}`, which the core plugin derives from `<inceptionYear>2020</inceptionYear>`. Verified in a full clone by running `license:check` three ways — 4.6 with the extension (main), 5.1.1 with the extension (#1178), and 5.1.1 without it — all three flag exactly the same two files. Removing it eliminates the version-skew failure mode outright and drops JGit from the build.

**Bumps `license-maven-plugin` to 5.1.1** and deletes the Java 8 comment. Dependabot had rewritten it to `5.1.1 is the last version supporting Java 8`, which is false: 4.6 is class file major 52 (Java 8), 5.1.1 is 55 (Java 11). The pin is moot regardless — `maven.compiler.testRelease` is 17 and every workflow runs on 17, so this cannot be built on a Java 8 JVM anyway. `maven.compiler.source/target=8` for the produced artifact is untouched.

**Normalizes two copyright headers.** `MavenMojoProjectParserIsExcludedTest` and `MavenPomCacheBuilderTest` carry `Copyright 2026` where the configuration renders `2020`, so `license:check` on its own is red on main today — CI hides it because the `format` execution bound to `process-sources` silently repairs them before `check` runs at `verify`. The other 33 source files all say 2020.

## Verification

Run against a fresh full clone, since JGit cannot read a linked git worktree:

- `license:check` alone: fails on main, passes here.
- `license:format`: no residual changes, so the bump is behaviour-neutral.