### PR TITLE
Reach the Code Genome Project from the release and bump workflows

### DIFF
--- a/.github/workflows/bump-snapshots.yml
+++ b/.github/workflows/bump-snapshots.yml
@@ -19,8 +19,9 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: maven
-          server-id: ossrh
-          settings-path: ${{ github.workspace }}
+          server-id: codegenome
+          server-username: CODEGENOME_USERNAME
+          server-password: CODEGENOME_TOKEN
       - name: configure-git-user
         run: |
           git config user.email "team@moderne.io"
@@ -30,3 +31,6 @@ jobs:
         run: |
           ./mvnw versions:update-properties -DincludeProperties=rewrite.version,rewrite-polyglot.version -DallowSnapshots=true
           git diff-index --quiet HEAD pom.xml || (git commit -m "Bump rewrite.version property" pom.xml && git push origin main)
+        env:
+          CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+          CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,14 @@ jobs:
           CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
       - name: publish-snapshots
         if: github.event_name != 'pull_request'
-        run: ./mvnw --show-version --settings=${{ github.workspace }}/settings.xml --file=pom.xml --batch-mode -Dstyle.color=always --activate-profiles=sign-artifacts clean deploy -DskipTests
+        run: ./mvnw --show-version --global-settings=$HOME/.m2/settings.xml --settings=${{ github.workspace }}/settings.xml --file=pom.xml --batch-mode -Dstyle.color=always --activate-profiles=sign-artifacts clean deploy -DskipTests
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
           SONATYPE_SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+          CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+          CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
       - name: slack-notification
         if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,15 @@ jobs:
           server-password: SONATYPE_PASSWORD
           gpg-private-key: ${{ secrets.OSSRH_SIGNING_KEY }}
           gpg-passphrase: SONATYPE_SIGNING_PASSWORD
+      # setup-java writes a single server per call, so codegenome goes in ~/.m2/settings.xml and
+      # the steps that pass --settings pass it as --global-settings for Maven to merge.
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          server-id: codegenome
+          server-username: CODEGENOME_USERNAME
+          server-password: CODEGENOME_TOKEN
       - name: configure-git-user
         run: |
           git config user.email "team@moderne.io"
@@ -41,14 +50,19 @@ jobs:
         run: |
           ./mvnw versions:update-properties -DincludeProperties=rewrite.version,rewrite-polyglot.version -DallowDowngrade=true
           git diff-index --quiet HEAD pom.xml || git commit -m "Bump rewrite.version property" pom.xml && rm -f pom.xml.versionsBackup
+        env:
+          CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+          CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
 
       - name: publish-release
-        run: ./mvnw --show-version --settings=${{ github.workspace }}/settings.xml --file=pom.xml --activate-profiles=sign-artifacts,release,release-automation help:active-profiles release:prepare release:perform --batch-mode -Dstyle.color=always
+        run: ./mvnw --show-version --global-settings=$HOME/.m2/settings.xml --settings=${{ github.workspace }}/settings.xml --file=pom.xml --activate-profiles=sign-artifacts,release,release-automation help:active-profiles release:prepare release:perform --batch-mode -Dstyle.color=always
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
           SONATYPE_SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+          CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+          CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
 
       - name: github-release
         if: ${{ success() }}
@@ -71,3 +85,6 @@ jobs:
         run: |
           ./mvnw versions:update-properties -DincludeProperties=rewrite.version,rewrite-polyglot.version -DallowSnapshots=true
           git diff-index --quiet HEAD pom.xml || (git commit -m "Bump rewrite.version property" pom.xml && git push origin main && rm -f pom.xml.versionsBackup)
+        env:
+          CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+          CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}


### PR DESCRIPTION
- Follow-up to #1183. That PR added the `codegenome` profile to `pom.xml` and exported `CODEGENOME_USERNAME`/`CODEGENOME_TOKEN` on `ci.yml`'s `build` step — but only that step. Everywhere else the profile silently stays inactive, because it activates on the presence of `env.CODEGENOME_USERNAME`.

### What that costs today

- **`bump-snapshots.yml`** runs `versions:update-properties` against Maven Central and `ossrh-snapshots` only. A `rewrite.version` published solely to CGP is invisible to it, and the failure mode is silence: the weekly job just stops finding newer snapshots. `publish.yml` runs the same goal twice and has the same blind spot.
- **`publish.yml`**'s `release:prepare`/`release:perform` rebuilds from a fresh checkout on a fresh runner. Any CGP-only dependency fails outright there.
- **`ci.yml`**'s `publish-snapshots` step is unaffected in practice — it runs after `build` on the same runner, so `~/.m2` is already warm — but it inherits the same wiring gap.

None of this bites while CGP publishing is additive to Sonatype (`RewriteCgpPublishPlugin` registers the S3 bucket "so `publish` uploads there **too**"). It bites when ossrh snapshot publishing stops.

### The `--global-settings` bit

`setup-java` writes a single server per call and overwrites `settings.xml` on each one, so the two servers can't come from one file. Steps that pass `--settings=$GITHUB_WORKSPACE/settings.xml` ignore `~/.m2/settings.xml` entirely, so a second `setup-java` call alone wouldn't reach them — worse, exporting the env var without credentials would activate the profile and send unauthenticated requests at CGP.

So those steps now pass the codegenome file as `--global-settings` as well. Maven merges global and user settings, unioning servers with distinct ids. Verified locally:

```
$ ./mvnw --global-settings=global.xml --settings=user.xml help:effective-settings
      <id>ossrh</id>
      <id>codegenome</id>
```

`release:perform` forks a Maven process, and the release plugin propagates the outer build's effective settings to it, so the fork inherits the merged servers; the profile re-activates in the fork from the inherited env.

### Notes

- `bump-snapshots.yml` deploys nothing, so its `ossrh` server was unused — that call is repurposed for `codegenome` rather than adding a third.
- The `rollback` step is left alone: `release:rollback` reverts poms and drops the tag, and resolves nothing from CGP.
- Fork PRs receive no secrets, so the profile stays inactive there, unchanged from #1183.
- Repository *order* is already correct — the effective pom with the profile active resolves `codegenome` → `ossrh-snapshots` → `central`, matching what `RewriteDependencyRepositoriesPluginTest.codegenomeResolvedBeforeSnapshotsAndMavenCentral` asserts on the Gradle side. Out of scope here, but unlike the Gradle plugin the pom can't group-scope CGP to `org.openrewrite`/`io.moderne`, so every third-party artifact is queried against it first.