### PR TITLE
Publish releases and snapshots to the Code Genome Project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,11 @@ jobs:
           CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
           CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
 
+      # The same snapshots again, to the Code Genome Project; the AWS credentials below activate the
+      # codegenome-publish profile, which points distributionManagement at its bucket.
       - name: publish-snapshots-codegenome
         if: github.event_name != 'pull_request'
-        run: ./mvnw --show-version --global-settings=$HOME/.m2/settings.xml --settings=${{ github.workspace }}/settings.xml --file=pom.xml --batch-mode -Dstyle.color=always --activate-profiles=sign-artifacts,codegenome-publish deploy -Dmaven.test.skip=true
+        run: ./mvnw --show-version --global-settings=$HOME/.m2/settings.xml --settings=${{ github.workspace }}/settings.xml --file=pom.xml --batch-mode -Dstyle.color=always --activate-profiles=sign-artifacts deploy -Dmaven.test.skip=true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,18 @@ jobs:
           SONATYPE_SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
           CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
           CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
+
+      - name: publish-snapshots-codegenome
+        if: github.event_name != 'pull_request'
+        run: ./mvnw --show-version --global-settings=$HOME/.m2/settings.xml --settings=${{ github.workspace }}/settings.xml --file=pom.xml --batch-mode -Dstyle.color=always --activate-profiles=sign-artifacts,codegenome-publish deploy -Dmaven.test.skip=true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+          SONATYPE_SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+          CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+          CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
+
       - name: slack-notification
         if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,11 +92,12 @@ jobs:
           CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
           CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
 
-      # Deploy the artifacts release:perform left in target/checkout to the Code Genome Project too;
-      # last, so a failure here costs only the mirror and not the tag, the release or the version bump.
+      # Deploy the artifacts release:perform left in target/checkout to the Code Genome Project too, as
+      # the AWS credentials below activate the codegenome-publish profile. Last, so a failure here costs
+      # only that copy and not the tag, the release or the version bump.
       - name: publish-release-codegenome
         working-directory: target/checkout
-        run: ./mvnw --show-version --global-settings=$HOME/.m2/settings.xml --settings=${{ github.workspace }}/settings.xml --file=pom.xml --activate-profiles=sign-artifacts,codegenome-publish deploy -Dmaven.test.skip=true --batch-mode -Dstyle.color=always
+        run: ./mvnw --show-version --global-settings=$HOME/.m2/settings.xml --settings=${{ github.workspace }}/settings.xml --file=pom.xml --activate-profiles=sign-artifacts deploy -Dmaven.test.skip=true --batch-mode -Dstyle.color=always
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,7 @@ jobs:
           CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
 
       - name: publish-release
+        id: publish-release
         run: ./mvnw --show-version --global-settings=$HOME/.m2/settings.xml --settings=${{ github.workspace }}/settings.xml --file=pom.xml --activate-profiles=sign-artifacts,release,release-automation help:active-profiles release:prepare release:perform --batch-mode -Dstyle.color=always
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -76,7 +77,9 @@ jobs:
               --generate-notes
 
       - name: rollback
-        if: ${{ failure() }}
+        # Only undo a release that failed to publish; a later step failing leaves the tag and the
+        # Sonatype release in place, so rolling back the poms would only add confusion.
+        if: ${{ failure() && steps.publish-release.outcome == 'failure' }}
         run: ./mvnw --show-version --settings=${{github.workspace}}/settings.xml --file=pom.xml --activate-profiles=sign-artifacts,release,release-automation help:active-profiles release:rollback --batch-mode -Dstyle.color=always
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -86,5 +89,18 @@ jobs:
           ./mvnw versions:update-properties -DincludeProperties=rewrite.version,rewrite-polyglot.version -DallowSnapshots=true
           git diff-index --quiet HEAD pom.xml || (git commit -m "Bump rewrite.version property" pom.xml && git push origin main && rm -f pom.xml.versionsBackup)
         env:
+          CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+          CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
+
+      # Deploy the artifacts release:perform left in target/checkout to the Code Genome Project too;
+      # last, so a failure here costs only the mirror and not the tag, the release or the version bump.
+      - name: publish-release-codegenome
+        working-directory: target/checkout
+        run: ./mvnw --show-version --global-settings=$HOME/.m2/settings.xml --settings=${{ github.workspace }}/settings.xml --file=pom.xml --activate-profiles=sign-artifacts,codegenome-publish deploy -Dmaven.test.skip=true --batch-mode -Dstyle.color=always
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+          SONATYPE_SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
           CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
           CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -4,4 +4,10 @@
     <artifactId>develocity-maven-extension</artifactId>
     <version>2.2.1</version>
   </extension>
+  <!-- s3 wagon for the codegenome-publish profile; artifacts.codegenomeproject.org is read-only -->
+  <extension>
+    <groupId>net.pennix</groupId>
+    <artifactId>maven-wagon-s3v2</artifactId>
+    <version>1.0.3</version>
+  </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -552,6 +552,23 @@
         </profile>
 
         <profile>
+            <!-- Deploy to the Code Genome Project alongside Maven Central; artifacts.codegenomeproject.org
+                 is read-only, so writes go straight to the bucket behind it, through the s3 wagon in
+                 .mvn/extensions.xml. Credentials and region come from the AWS environment. -->
+            <id>codegenome-publish</id>
+            <distributionManagement>
+                <repository>
+                    <id>codegenome-s3</id>
+                    <url>s3://codegenome-artifacts/maven</url>
+                </repository>
+                <snapshotRepository>
+                    <id>codegenome-s3</id>
+                    <url>s3://codegenome-artifacts/maven</url>
+                </snapshotRepository>
+            </distributionManagement>
+        </profile>
+
+        <profile>
             <id>sign-artifacts</id>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -554,8 +554,15 @@
         <profile>
             <!-- Deploy to the Code Genome Project alongside Maven Central; artifacts.codegenomeproject.org
                  is read-only, so writes go straight to the bucket behind it, through the s3 wagon in
-                 .mvn/extensions.xml. Credentials and region come from the AWS environment. -->
+                 .mvn/extensions.xml. Credentials and region come from the AWS environment, which the
+                 workflows export on the codegenome deploy steps only, so every other deploy keeps
+                 the Sonatype distributionManagement this overrides. -->
             <id>codegenome-publish</id>
+            <activation>
+                <property>
+                    <name>env.AWS_ACCESS_KEY_ID</name>
+                </property>
+            </activation>
             <distributionManagement>
                 <repository>
                     <id>codegenome-s3</id>

--- a/pom.xml
+++ b/pom.xml
@@ -552,11 +552,6 @@
         </profile>
 
         <profile>
-            <!-- Deploy to the Code Genome Project alongside Maven Central; artifacts.codegenomeproject.org
-                 is read-only, so writes go straight to the bucket behind it, through the s3 wagon in
-                 .mvn/extensions.xml. Credentials and region come from the AWS environment, which the
-                 workflows export on the codegenome deploy steps only, so every other deploy keeps
-                 the Sonatype distributionManagement this overrides. -->
             <id>codegenome-publish</id>
             <activation>
                 <property>


### PR DESCRIPTION
`6.46.0` released cleanly but never showed up under [`/maven/org/openrewrite/maven/rewrite-maven-plugin/`](https://artifacts.codegenomeproject.org/maven/org/openrewrite/maven/rewrite-maven-plugin/) — CGP still lists `6.45.0` as `<release>`.

- The reason is that nothing here ever *pushes* to CGP. `#1183`/`#1190` added the `codegenome` profile and forwarded `CGP_ARTIFACTS_MAVEN_*`, but that is resolution only; `distributionManagement` points at Sonatype alone. The versions CGP does host arrived after the fact, from `sync-recipes.sh`/`backfill-recipes.sh` in `moderneinc/codegenomeproject` mirroring Maven Central — manual scripts, no schedule, and a path that disappears as publishing moves off Central.

Gradle repositories get a real dual publish from `RewriteCgpPublishPlugin`, which adds the CGP bucket as a second publishing repository. There is no Maven counterpart, so this wires the equivalent by hand:

- `.mvn/extensions.xml` gains `net.pennix:maven-wagon-s3v2`. The HTTP service is read-only, so deploys go to `s3://codegenome-artifacts/maven` directly; the wagon takes credentials and region from the AWS environment. A profile can't declare `<build><extensions>`, hence the core extension.
- A `codegenome-publish` profile overrides `distributionManagement` to that bucket. Inactive unless explicitly requested, so ordinary builds and the Sonatype deploy are untouched.
- `publish.yml` redeploys the artifacts `release:perform` already built in `target/checkout`, as the last step — a failure there costs only the CGP copy, not the tag, the GitHub release or the version bump. `rollback` is narrowed to `publish-release` failing so it can no longer fire on a release that already went out.
- `ci.yml` pushes snapshots the same way, which is what ADR 0013 expects publishers to do (Central has no snapshots, and `gc-snapshots.sh` reclaims them once the release ships).

Maven merges the remote `maven-metadata.xml` on deploy, so `<versions>`/`<release>`/`<latest>` follow the semantics `regen-metadata.sh` implements — `<latest>` may be a snapshot, `<release>` only ever a release.

Verified locally that the wagon loads from `.mvn/extensions.xml` and that an `s3://` deploy reaches S3 (fails on credentials, not on a missing connector), and that the profile flips `distributionManagement` to the bucket while the default stays Sonatype.

`6.46.0` itself still needs a one-off backfill: `scripts/sync-recipes.sh org.openrewrite.maven:rewrite-maven-plugin:6.46.0` from `moderneinc/codegenomeproject`, by someone with bucket write credentials.