### PR TITLE
Include invalid value in recipe validation error log

### DIFF
--- a/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
+++ b/src/main/java/org/openrewrite/maven/AbstractRewriteBaseRunMojo.java
@@ -142,9 +142,10 @@ public abstract class AbstractRewriteBaseRunMojo extends AbstractRewriteMojo {
             if (!failedValidations.isEmpty()) {
                 failedValidations.forEach(failedValidation -> getLog().error(
                         String.format(
-                                "Recipe validation error in %s for property %s: %s",
+                                "Recipe validation error in %s for property %s with invalid value %s: %s",
                                 recipe.getName(),
                                 failedValidation.getProperty(),
+                                failedValidation.getInvalidValue(),
                                 failedValidation.getMessage()),
                         failedValidation.getException()));
                 if (failOnInvalidActiveRecipes) {


### PR DESCRIPTION
Recipe validation failures now log the offending value alongside the property name and message, so users can see what was actually configured without having to cross-reference their pom.

`Validated.Invalid.getInvalidValue()` returns `Object`, so a null value formats as `null` rather than throwing.