### PR TITLE
Let integration tests resolve OpenRewrite snapshots from the Code Genome Project

### DIFF
--- a/src/test/resources-its/org/openrewrite/maven/BasicIT/resolves_settings/settings-user.xml
+++ b/src/test/resources-its/org/openrewrite/maven/BasicIT/resolves_settings/settings-user.xml
@@ -1,6 +1,16 @@
 <settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                     http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <!-- Replaces the user settings written by the CI job, so the plugin under test can still resolve
+         its org.openrewrite snapshot dependencies from the Code Genome Project. -->
+    <servers>
+        <server>
+            <id>codegenome</id>
+            <username>${env.CODEGENOME_USERNAME}</username>
+            <password>${env.CODEGENOME_TOKEN}</password>
+        </server>
+    </servers>
+
     <profiles>
         <profile>
             <id>example_profile_id</id>

--- a/src/test/resources-its/org/openrewrite/maven/KotlinIT/kotlin_in_src_main_java/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/KotlinIT/kotlin_in_src_main_java/pom.xml
@@ -113,8 +113,8 @@
         <profile>
             <!-- Resolve org.openrewrite artifacts from the Code Genome Project rather than Maven Central.
                  Inactive on fork builds, which receive no credentials and fall back to Maven Central.
-                 Releases only: the plugin under test is served from the itf repository, and fetching
-                 snapshot metadata from the Code Genome Project emits checksum warnings the ITs assert against. -->
+                 Snapshots enabled: the plugin under test depends on org.openrewrite snapshots, which
+                 are published solely to the Code Genome Project. -->
             <id>codegenome</id>
             <activation>
                 <property>
@@ -126,7 +126,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </repository>
             </repositories>
@@ -135,7 +135,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>

--- a/src/test/resources-its/org/openrewrite/maven/KotlinIT/kotlin_in_src_main_test/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/KotlinIT/kotlin_in_src_main_test/pom.xml
@@ -113,8 +113,8 @@
         <profile>
             <!-- Resolve org.openrewrite artifacts from the Code Genome Project rather than Maven Central.
                  Inactive on fork builds, which receive no credentials and fall back to Maven Central.
-                 Releases only: the plugin under test is served from the itf repository, and fetching
-                 snapshot metadata from the Code Genome Project emits checksum warnings the ITs assert against. -->
+                 Snapshots enabled: the plugin under test depends on org.openrewrite snapshots, which
+                 are published solely to the Code Genome Project. -->
             <id>codegenome</id>
             <activation>
                 <property>
@@ -126,7 +126,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </repository>
             </repositories>
@@ -135,7 +135,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/multi_module_project/pom.xml
@@ -48,8 +48,8 @@
         <profile>
             <!-- Resolve org.openrewrite artifacts from the Code Genome Project rather than Maven Central.
                  Inactive on fork builds, which receive no credentials and fall back to Maven Central.
-                 Releases only: the plugin under test is served from the itf repository, and fetching
-                 snapshot metadata from the Code Genome Project emits checksum warnings the ITs assert against. -->
+                 Snapshots enabled: the plugin under test depends on org.openrewrite snapshots, which
+                 are published solely to the Code Genome Project. -->
             <id>codegenome</id>
             <activation>
                 <property>
@@ -61,7 +61,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </repository>
             </repositories>
@@ -70,7 +70,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/no_plugin_in_pom/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/no_plugin_in_pom/pom.xml
@@ -34,8 +34,8 @@
         <profile>
             <!-- Resolve org.openrewrite artifacts from the Code Genome Project rather than Maven Central.
                  Inactive on fork builds, which receive no credentials and fall back to Maven Central.
-                 Releases only: the plugin under test is served from the itf repository, and fetching
-                 snapshot metadata from the Code Genome Project emits checksum warnings the ITs assert against. -->
+                 Snapshots enabled: the plugin under test depends on org.openrewrite snapshots, which
+                 are published solely to the Code Genome Project. -->
             <id>codegenome</id>
             <activation>
                 <property>
@@ -47,7 +47,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </repository>
             </repositories>
@@ -56,7 +56,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/recipe_order/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteDryRunIT/recipe_order/pom.xml
@@ -46,8 +46,8 @@
         <profile>
             <!-- Resolve org.openrewrite artifacts from the Code Genome Project rather than Maven Central.
                  Inactive on fork builds, which receive no credentials and fall back to Maven Central.
-                 Releases only: the plugin under test is served from the itf repository, and fetching
-                 snapshot metadata from the Code Genome Project emits checksum warnings the ITs assert against. -->
+                 Snapshots enabled: the plugin under test depends on org.openrewrite snapshots, which
+                 are published solely to the Code Genome Project. -->
             <id>codegenome</id>
             <activation>
                 <property>
@@ -59,7 +59,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </repository>
             </repositories>
@@ -68,7 +68,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/java_upgrade_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/java_upgrade_project/pom.xml
@@ -41,8 +41,8 @@
         <profile>
             <!-- Resolve org.openrewrite artifacts from the Code Genome Project rather than Maven Central.
                  Inactive on fork builds, which receive no credentials and fall back to Maven Central.
-                 Releases only: the plugin under test is served from the itf repository, and fetching
-                 snapshot metadata from the Code Genome Project emits checksum warnings the ITs assert against. -->
+                 Snapshots enabled: the plugin under test depends on org.openrewrite snapshots, which
+                 are published solely to the Code Genome Project. -->
             <id>codegenome</id>
             <activation>
                 <property>
@@ -54,7 +54,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </repository>
             </repositories>
@@ -63,7 +63,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_project/pom.xml
@@ -48,8 +48,8 @@
         <profile>
             <!-- Resolve org.openrewrite artifacts from the Code Genome Project rather than Maven Central.
                  Inactive on fork builds, which receive no credentials and fall back to Maven Central.
-                 Releases only: the plugin under test is served from the itf repository, and fetching
-                 snapshot metadata from the Code Genome Project emits checksum warnings the ITs assert against. -->
+                 Snapshots enabled: the plugin under test depends on org.openrewrite snapshots, which
+                 are published solely to the Code Genome Project. -->
             <id>codegenome</id>
             <activation>
                 <property>
@@ -61,7 +61,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </repository>
             </repositories>
@@ -70,7 +70,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_resources/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/multi_module_resources/pom.xml
@@ -47,8 +47,8 @@
         <profile>
             <!-- Resolve org.openrewrite artifacts from the Code Genome Project rather than Maven Central.
                  Inactive on fork builds, which receive no credentials and fall back to Maven Central.
-                 Releases only: the plugin under test is served from the itf repository, and fetching
-                 snapshot metadata from the Code Genome Project emits checksum warnings the ITs assert against. -->
+                 Snapshots enabled: the plugin under test depends on org.openrewrite snapshots, which
+                 are published solely to the Code Genome Project. -->
             <id>codegenome</id>
             <activation>
                 <property>
@@ -60,7 +60,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </repository>
             </repositories>
@@ -69,7 +69,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/plaintext_masks/pom.xml
@@ -44,8 +44,8 @@
         <profile>
             <!-- Resolve org.openrewrite artifacts from the Code Genome Project rather than Maven Central.
                  Inactive on fork builds, which receive no credentials and fall back to Maven Central.
-                 Releases only: the plugin under test is served from the itf repository, and fetching
-                 snapshot metadata from the Code Genome Project emits checksum warnings the ITs assert against. -->
+                 Snapshots enabled: the plugin under test depends on org.openrewrite snapshots, which
+                 are published solely to the Code Genome Project. -->
             <id>codegenome</id>
             <activation>
                 <property>
@@ -57,7 +57,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </repository>
             </repositories>
@@ -66,7 +66,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/recipe_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunIT/recipe_project/pom.xml
@@ -49,8 +49,8 @@
         <profile>
             <!-- Resolve org.openrewrite artifacts from the Code Genome Project rather than Maven Central.
                  Inactive on fork builds, which receive no credentials and fall back to Maven Central.
-                 Releases only: the plugin under test is served from the itf repository, and fetching
-                 snapshot metadata from the Code Genome Project emits checksum warnings the ITs assert against. -->
+                 Snapshots enabled: the plugin under test depends on org.openrewrite snapshots, which
+                 are published solely to the Code Genome Project. -->
             <id>codegenome</id>
             <activation>
                 <property>
@@ -62,7 +62,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </repository>
             </repositories>
@@ -71,7 +71,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>

--- a/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/pom.xml
+++ b/src/test/resources-its/org/openrewrite/maven/RewriteRunParallelIT/multi_module_project/pom.xml
@@ -48,8 +48,8 @@
         <profile>
             <!-- Resolve org.openrewrite artifacts from the Code Genome Project rather than Maven Central.
                  Inactive on fork builds, which receive no credentials and fall back to Maven Central.
-                 Releases only: the plugin under test is served from the itf repository, and fetching
-                 snapshot metadata from the Code Genome Project emits checksum warnings the ITs assert against. -->
+                 Snapshots enabled: the plugin under test depends on org.openrewrite snapshots, which
+                 are published solely to the Code Genome Project. -->
             <id>codegenome</id>
             <activation>
                 <property>
@@ -61,7 +61,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </repository>
             </repositories>
@@ -70,7 +70,7 @@
                     <id>codegenome</id>
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>


### PR DESCRIPTION
CI has been deterministically red since the post-release `Bump rewrite.version property` commit moved `rewrite.version` to `8.92.0-SNAPSHOT`: OpenRewrite snapshots are published solely to the Code Genome Project, and the itf integration tests run nested Maven builds with their own local repository, so they resolve the plugin's transitives from scratch.

The 11 fixture poms declared a repository with id `codegenome` but snapshots disabled, and since Maven dedupes remote repositories by id that definition shadowed the snapshot-enabled one the plugin's own pom contributes — leaving only `ossrh-snapshots` eligible for snapshots, which 404s (`KotlinIT` was the only fixture pulling in modules the plugin doesn't already depend on, via `rewrite-all`). This enables snapshots on those repositories and adds the `codegenome` server credentials to `BasicIT.resolves_settings`' own `settings-user.xml`, which replaces the user settings written by CI and so was reaching the Code Genome Project anonymously (401 on metadata, then 422 on the non-timestamped pom).

The "checksum warnings the ITs assert against" rationale in the old comment no longer reproduces: the last CI run fetched snapshot metadata from the Code Genome Project without a single integrity warning, and the served `maven-metadata.xml.sha1` now matches the served bytes. Fork builds get no credentials and are unaffected by this change (they are already broken for the release line too, since `rewrite-core:8.91.0` is not on Maven Central).