### PR TITLE
Resolve OpenRewrite snapshots from the Code Genome Project in the Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,8 +37,15 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: maven
+          server-id: codegenome
+          server-username: CODEGENOME_USERNAME
+          server-password: CODEGENOME_TOKEN
       - name: site
         run: ./mvnw --show-version --update-snapshots clean site --file=pom.xml --fail-at-end --batch-mode -Dstyle.color=always -Ddependency-check.skip=true
+        env:
+          # Activates the codegenome profile in pom.xml, which serves the upstream OpenRewrite snapshots.
+          CODEGENOME_USERNAME: ${{ secrets.CODEGENOME_USERNAME }}
+          CODEGENOME_TOKEN: ${{ secrets.CODEGENOME_TOKEN }}
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:


### PR DESCRIPTION
The `Deploy plugin docs to Pages` workflow [fails](https://github.com/openrewrite/rewrite-maven-plugin/actions/runs/32998328437/job/98273279797) to build the site:

```
Non-resolvable import POM: The following artifacts could not be resolved:
org.openrewrite:rewrite-bom:pom:8.92.0-SNAPSHOT (absent): Could not find artifact
org.openrewrite:rewrite-bom:pom:8.92.0-SNAPSHOT in ossrh-snapshots
```

Upstream OpenRewrite snapshots now live in the Code Genome Project repository rather than ossrh-snapshots. The `codegenome` profile in `pom.xml` adds that repository, but it activates on `env.CODEGENOME_USERNAME`, and `pages.yml` was the one workflow that never got those credentials wired up (`ci.yml`, `publish.yml` and `bump-snapshots.yml` all have them).

Mirrors the setup in `ci.yml`: `server-id: codegenome` on `setup-java`, plus the `CODEGENOME_USERNAME`/`CODEGENOME_TOKEN` env on the `site` step.